### PR TITLE
Improve Rust FFI bulk and streaming paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Bulk payload v2:** Dart `BulkInsertBuilder.build()` now emits the `BLK2`
+  wire format by default and exposes `BulkPayloadVersion { legacy, v2 }`.
+  Rust auto-detects v1/v2 in `odbc_bulk_insert_array` and
+  `odbc_bulk_insert_parallel`, preserving compatibility with existing payloads.
+- **Regression coverage:** added Rust coverage for bulk v2 binary cells with
+  embedded `NUL`, variable-length binary cells, truncation and max-length
+  validation, pending-result replay, per-connection errors, parallel bulk
+  chunking, and streaming spill encoding. Dart coverage now verifies the v2
+  default, legacy format opt-in, binary `NUL` preservation, and `maxLen`
+  validation.
+
+### Fixed
+
+- **Binary bulk insert correctness:** v2 variable-width cells carry a per-cell
+  length, so binary values such as `Uint8List([1, 0, 2])` are no longer
+  truncated at the first `0x00`.
+- **FFI concurrency:** long ODBC calls in query, prepared execution, streaming,
+  and bulk insert paths no longer run while `GLOBAL_STATE` is locked. The global
+  mutex is now limited to lookup/registration, pending-buffer replay, metrics,
+  and error recording.
+
+### Changed
+
+- **Bulk/streaming performance:** pool-based parallel bulk insert uses row
+  ranges/views on the default ArrayBinding path to avoid cloning each chunk's
+  full payload. The `sqlserver-bcp` feature keeps a documented chunk
+  materialization fallback because the BCP executor consumes an owned payload.
+- **Statement reuse docs:** documentation now states that
+  `statement-handle-reuse` remains opt-in and that the default path keeps only
+  metrics/cache metadata, not reusable statement handles.
+
 ## [3.6.0] - 2026-05-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,9 +41,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full payload. Row-buffer encoding now preallocates the final wire buffer,
   spill encoding avoids per-chunk temporary `Vec` allocations, and file-backed
   streaming keeps the spill file open while fetching chunks instead of
-  reopening/seeking on every read. The `sqlserver-bcp` feature keeps a
-  documented chunk materialization fallback because the BCP executor consumes
-  an owned payload.
+  reopening/seeking on every read. Bulk payload serialization preallocates the
+  expected output size, legacy bulk text/binary parsing copies only the trimmed
+  cell bytes, and multi-result encoding validates/preallocates payload size
+  before writing. The `sqlserver-bcp` feature keeps a documented chunk
+  materialization fallback because the BCP executor consumes an owned payload.
 - **Statement reuse docs:** documentation now states that
   `statement-handle-reuse` remains opt-in and that the default path keeps only
   metrics/cache metadata, not reusable statement handles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   full payload. Row-buffer encoding now preallocates the final wire buffer,
   spill encoding avoids per-chunk temporary `Vec` allocations, and file-backed
   streaming keeps the spill file open while fetching chunks instead of
-  reopening/seeking on every read. Bulk payload serialization preallocates the
-  expected output size, legacy bulk text/binary parsing copies only the trimmed
-  cell bytes, and multi-result encoding validates/preallocates payload size
-  before writing. Columnar encoding writes uncompressed column payloads directly
-  into the final buffer, parameter-list serialization writes into one
-  preallocated buffer, and ArrayBinding SQL assembly avoids temporary `Vec`
-  joins for placeholders/columns. The `sqlserver-bcp` feature keeps a
+  reopening/seeking on every read. `odbc_stream_fetch` now copies stream chunks
+  directly into the caller buffer, avoiding an intermediate `Vec` allocation
+  and removing the pending-chunk copy path on `-2` retries. Binary cell reads
+  retain the internal scratch-buffer capacity between cells to reduce repeated
+  allocations on binary-heavy result sets. Bulk payload serialization
+  preallocates the expected output size, legacy bulk text/binary parsing copies
+  only the trimmed cell bytes, and multi-result encoding validates/preallocates
+  payload size before writing. Columnar encoding writes uncompressed column
+  payloads directly into the final buffer, parameter-list serialization writes
+  into one preallocated buffer, and ArrayBinding SQL assembly avoids temporary
+  `Vec` joins for placeholders/columns. The `sqlserver-bcp` feature keeps a
   documented chunk materialization fallback because the BCP executor consumes
   an owned payload.
 - **Statement reuse docs:** documentation now states that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,8 +44,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   reopening/seeking on every read. Bulk payload serialization preallocates the
   expected output size, legacy bulk text/binary parsing copies only the trimmed
   cell bytes, and multi-result encoding validates/preallocates payload size
-  before writing. The `sqlserver-bcp` feature keeps a documented chunk
-  materialization fallback because the BCP executor consumes an owned payload.
+  before writing. Columnar encoding writes uncompressed column payloads directly
+  into the final buffer, parameter-list serialization writes into one
+  preallocated buffer, and ArrayBinding SQL assembly avoids temporary `Vec`
+  joins for placeholders/columns. The `sqlserver-bcp` feature keeps a
+  documented chunk materialization fallback because the BCP executor consumes
+  an owned payload.
 - **Statement reuse docs:** documentation now states that
   `statement-handle-reuse` remains opt-in and that the default path keeps only
   metrics/cache metadata, not reusable statement handles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   validation, pending-result replay, per-connection errors, parallel bulk
   chunking, and streaming spill encoding. Dart coverage now verifies the v2
   default, legacy format opt-in, binary `NUL` preservation, and `maxLen`
-  validation.
+  validation. Opt-in Rust E2E coverage now exercises bulk v2 binary readback,
+  global-state availability during long FFI calls, pool close/resize busy
+  guards during in-flight pooled execution, and spill-backed streaming.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Bulk/streaming performance:** pool-based parallel bulk insert uses row
   ranges/views on the default ArrayBinding path to avoid cloning each chunk's
-  full payload. The `sqlserver-bcp` feature keeps a documented chunk
-  materialization fallback because the BCP executor consumes an owned payload.
+  full payload. Row-buffer encoding now preallocates the final wire buffer,
+  spill encoding avoids per-chunk temporary `Vec` allocations, and file-backed
+  streaming keeps the spill file open while fetching chunks instead of
+  reopening/seeking on every read. The `sqlserver-bcp` feature keeps a
+  documented chunk materialization fallback because the BCP executor consumes
+  an owned payload.
 - **Statement reuse docs:** documentation now states that
   `statement-handle-reuse` remains opt-in and that the default path keeps only
   metrics/cache metadata, not reusable statement handles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Binary bulk insert correctness:** v2 variable-width cells carry a per-cell
   length, so binary values such as `Uint8List([1, 0, 2])` are no longer
   truncated at the first `0x00`.
-- **FFI concurrency:** long ODBC calls in query, prepared execution, streaming,
-  and bulk insert paths no longer run while `GLOBAL_STATE` is locked. The global
-  mutex is now limited to lookup/registration, pending-buffer replay, metrics,
-  and error recording.
+- **FFI concurrency:** long ODBC calls in connection lifecycle, query,
+  prepared execution, catalog metadata, savepoint/XA transitions, streaming,
+  pool release/close, and bulk insert paths no longer run while `GLOBAL_STATE`
+  is locked. The global mutex is now limited to lookup/registration,
+  pending-buffer replay, metrics, and error recording.
+- **Pool close/resize safety:** pooled connections temporarily removed from
+  global state for active FFI calls are tracked as busy, preventing pool close
+  or resize from racing an in-flight operation.
 
 ### Changed
 

--- a/lib/infrastructure/native/protocol/bulk_insert_builder.dart
+++ b/lib/infrastructure/native/protocol/bulk_insert_builder.dart
@@ -8,6 +8,9 @@ const int _tagDecimal = 3;
 const int _tagBinary = 4;
 const int _tagTimestamp = 5;
 const Endian _littleEndian = Endian.little;
+const List<int> _bulkPayloadV2Magic = [0x42, 0x4C, 0x4B, 0x32]; // BLK2
+const int _bulkPayloadV2Version = 2;
+const int _bulkPayloadV2Flags = 0;
 
 int _nullBitmapSize(int rowCount) => (rowCount / 8).ceil();
 
@@ -40,6 +43,19 @@ void _validateTextColumn(String value, BulkColumnSpec spec, int rowNumber) {
     throw ArgumentError(
       'Column "${spec.name}" UTF-8 encoding exceeds max length ${spec.maxLen} '
       '(got ${utf8Bytes.length} bytes) at row $rowNumber.',
+    );
+  }
+}
+
+void _validateBinaryColumn(
+  List<int> value,
+  BulkColumnSpec spec,
+  int rowNumber,
+) {
+  if (spec.maxLen > 0 && value.length > spec.maxLen) {
+    throw ArgumentError(
+      'Column "${spec.name}" exceeds max length ${spec.maxLen} '
+      '(got ${value.length} bytes) at row $rowNumber.',
     );
   }
 }
@@ -86,6 +102,7 @@ void _validateValueForColumn(
           '(${value.runtimeType}) at row $rowNumber.',
         );
       }
+      _validateTextColumn('$value', spec, rowNumber);
     case BulkColumnType.binary:
       if (value is! List<int>) {
         throw ArgumentError(
@@ -93,6 +110,7 @@ void _validateValueForColumn(
           '(${value.runtimeType}) at row $rowNumber.',
         );
       }
+      _validateBinaryColumn(value, spec, rowNumber);
     case BulkColumnType.timestamp:
       if (value is! DateTime && value is! BulkTimestamp) {
         throw ArgumentError(
@@ -131,6 +149,15 @@ List<int> _i16Le(int v) {
   final buffer = Uint8List(2);
   ByteData.view(buffer.buffer).setInt16(0, v, _littleEndian);
   return buffer;
+}
+
+/// Bulk insert wire payload version.
+enum BulkPayloadVersion {
+  /// Legacy fixed-width wire format without a magic header.
+  legacy,
+
+  /// Versioned wire format that stores variable-width cell lengths.
+  v2,
 }
 
 /// Column data types for bulk insert operations.
@@ -333,12 +360,17 @@ class BulkInsertBuilder {
 
   /// Builds the binary data buffer for bulk insert.
   ///
+  /// Version [BulkPayloadVersion.v2] is the default and preserves
+  /// variable-width binary values, including embedded NUL bytes. Use
+  /// [BulkPayloadVersion.legacy] only when talking to native engines that do
+  /// not understand the versioned `BLK2` payload.
+  ///
   /// Validates that table name, columns, and at least one row are present.
   /// Returns a [Uint8List] containing the serialized bulk insert data.
   ///
   /// Throws [StateError] if table name is empty, no columns are defined,
   /// no rows have been added, or a non-nullable column contains null.
-  Uint8List build() {
+  Uint8List build({BulkPayloadVersion version = BulkPayloadVersion.v2}) {
     if (_table.isEmpty) {
       throw StateError('Table name required');
     }
@@ -364,6 +396,13 @@ class BulkInsertBuilder {
     }
 
     final out = <int>[];
+    if (version == BulkPayloadVersion.v2) {
+      out
+        ..addAll(_bulkPayloadV2Magic)
+        ..addAll(_u16Le(_bulkPayloadV2Version))
+        ..addAll(_u16Le(_bulkPayloadV2Flags));
+    }
+
     final tableBytes = utf8.encode(_table);
     out
       ..addAll(_u32Le(tableBytes.length))
@@ -385,13 +424,17 @@ class BulkInsertBuilder {
 
     for (var c = 0; c < _columns.length; c++) {
       final spec = _columns[c];
-      _serializeColumn(out, spec, c, rowCount);
+      if (version == BulkPayloadVersion.v2) {
+        _serializeColumnV2(out, spec, c, rowCount);
+      } else {
+        _serializeColumnLegacy(out, spec, c, rowCount);
+      }
     }
 
     return Uint8List.fromList(out);
   }
 
-  void _serializeColumn(
+  void _serializeColumnLegacy(
     List<int> out,
     BulkColumnSpec spec,
     int colIndex,
@@ -519,6 +562,56 @@ class BulkInsertBuilder {
             ..addAll(_u16Le(t.minute))
             ..addAll(_u16Le(t.second))
             ..addAll(_u32Le(t.fraction));
+        }
+    }
+  }
+
+  void _serializeColumnV2(
+    List<int> out,
+    BulkColumnSpec spec,
+    int colIndex,
+    int rowCount,
+  ) {
+    List<int>? nullBitmap;
+    if (spec.nullable) {
+      nullBitmap = List.filled(_nullBitmapSize(rowCount), 0);
+    }
+
+    switch (spec.colType) {
+      case BulkColumnType.i32:
+      case BulkColumnType.i64:
+      case BulkColumnType.timestamp:
+        _serializeColumnLegacy(out, spec, colIndex, rowCount);
+      case BulkColumnType.text:
+      case BulkColumnType.decimal:
+        if (nullBitmap != null) {
+          for (var r = 0; r < rowCount; r++) {
+            if (_rows[r][colIndex] == null) _setNullAt(nullBitmap, r);
+          }
+          out.addAll(nullBitmap);
+        }
+        for (var r = 0; r < rowCount; r++) {
+          final v = _rows[r][colIndex];
+          final raw = v == null ? <int>[] : utf8.encode('$v');
+          out
+            ..addAll(_u32Le(raw.length))
+            ..addAll(raw);
+        }
+      case BulkColumnType.binary:
+        if (nullBitmap != null) {
+          for (var r = 0; r < rowCount; r++) {
+            if (_rows[r][colIndex] == null) _setNullAt(nullBitmap, r);
+          }
+          out.addAll(nullBitmap);
+        }
+        for (var r = 0; r < rowCount; r++) {
+          final v = _rows[r][colIndex];
+          final raw = v == null
+              ? <int>[]
+              : (v is Uint8List ? v.toList() : (v as List<int>));
+          out
+            ..addAll(_u32Le(raw.length))
+            ..addAll(raw);
         }
     }
   }

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -18,6 +18,11 @@ Columnar v2 encoding keeps that path for compressed columns, but writes
 uncompressed column payloads directly into the final output buffer to avoid a
 temporary per-column payload allocation.
 
+Binary result cells reuse an internal scratch buffer while reading from ODBC.
+When a cell is handed to the row buffer, the scratch buffer is recreated with
+the previous capacity so binary-heavy result sets avoid growing from zero for
+every cell.
+
 ### 1.1 Spill-to-disk for large buffers
 
 For cases where you want to build a large payload but avoid keeping it all in RAM,
@@ -34,6 +39,11 @@ it spills to temp file and `StreamingStateFileBacked` reads in chunks.
 of allocating a temporary `Vec` per flush chunk. File-backed streaming opens the
 spill file once and advances sequentially for each `fetch_next_chunk`, avoiding
 per-chunk open/seek overhead.
+
+The FFI fetch path uses `copy_next_chunk` to write stream chunks directly into
+the caller-provided buffer. If the buffer is too small, the stream offset is not
+advanced and the next call can retry with a larger buffer without storing a
+pending chunk copy in global state.
 
 The FFI global state mutex is not held while streaming prepares, executes,
 reads cursor rows, or encodes/spills data. It is used only for lookup and stream

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -14,6 +14,9 @@ Most APIs ultimately produce a `Vec<u8>` encoded by:
 This buffer is the unit transported over FFI (`odbc_exec_query`, streaming batches, etc).
 The current encoders pre-measure payload size where practical so the final
 `Vec<u8>` can be preallocated once instead of growing repeatedly while writing.
+Columnar v2 encoding keeps that path for compressed columns, but writes
+uncompressed column payloads directly into the final output buffer to avoid a
+temporary per-column payload allocation.
 
 ### 1.1 Spill-to-disk for large buffers
 

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -8,8 +8,12 @@ handling larger datasets: streaming, batching, pooling, transactions, and array 
 Most APIs ultimately produce a `Vec<u8>` encoded by:
 
 - `protocol::RowBufferEncoder::encode(&RowBuffer)`
+- `protocol::multi_result::encode_multi(...)` for multi-result responses
+- `protocol::bulk_insert::serialize_bulk_insert_payload(_v2)` for bulk inserts
 
 This buffer is the unit transported over FFI (`odbc_exec_query`, streaming batches, etc).
+The current encoders pre-measure payload size where practical so the final
+`Vec<u8>` can be preallocated once instead of growing repeatedly while writing.
 
 ### 1.1 Spill-to-disk for large buffers
 

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -216,6 +216,9 @@ These are implemented in Rust and used by the engine/FFI:
   - ID 0 is always reserved/invalid and indicates allocation failure.
   - See `ffi_conventions.md` for detailed ID allocation rules.
 - **E2E / coverage**:
-  - E2E tests may self-skip when no DSN is configured. See:
-    - `native/odbc_engine/E2E_TESTS_ENV_CONFIG.md`
-    - `native/odbc_engine/MULTI_DATABASE_TESTING.md`
+  - E2E tests may self-skip when `ENABLE_E2E_TESTS=1` and a usable DSN are not
+    configured. The Rust FFI refactor coverage lives in
+    `native/odbc_engine/tests/e2e_ffi_refactor_regression_test.rs` and requires
+    SQL Server because it uses `WAITFOR DELAY`, `VARBINARY`, and `DATALENGTH`.
+  - Run the focused refactor E2E suite with:
+    `ENABLE_E2E_TESTS=1 ODBC_TEST_DSN="<connection string>" cargo test --test e2e_ffi_refactor_regression_test --all-features`.

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -174,15 +174,17 @@ These are implemented in Rust and used by the engine/FFI:
   - Compatibility notes: `native/doc/bcp_dll_compatibility.md`.
 - **FFI pooled connections**:
   - Pooled connections are tracked separately from `odbc_connect` connections.
-  - `odbc_exec_query` / `odbc_exec_query_params` / `odbc_exec_query_multi` still operate on
-    `conn_id` from `odbc_connect`.
-  - `odbc_prepare` / `odbc_execute` accept both regular `conn_id` and pooled connection IDs.
+  - Query, prepared execution, catalog, streaming buffer mode, and bulk array paths accept
+    both regular `conn_id` and pooled connection IDs where the public FFI contract permits.
+  - Pooled connections temporarily removed from `GlobalState` for long FFI calls are counted
+    as busy, so pool close/resize cannot race an in-flight operation.
   - **Lifecycle hardening**: `odbc_pool_release_connection` and `odbc_pool_close` remove all
     prepared statements for the released/closed connections to avoid orphaned statements and
     connection reuse hazards.
   - **RAII (rollback/autocommit restore)**: On release and pool close, any active transaction is
     rolled back and autocommit is restored before the connection returns to the pool or is
-    dropped. This ensures clean connection state regardless of `test_on_checkout`.
+    dropped. This cleanup runs outside the global state lock and ensures clean connection state
+    regardless of `test_on_checkout`.
 - **Lock poisoning recovery**:
   - Critical runtime locks (Tracer, BufferPool, PreparedStatementCache, Metrics) use
     `lock().unwrap_or_else(|e| e.into_inner())` to recover from poisoning instead of panicking.
@@ -206,4 +208,3 @@ These are implemented in Rust and used by the engine/FFI:
   - E2E tests may self-skip when no DSN is configured. See:
     - `native/odbc_engine/E2E_TESTS_ENV_CONFIG.md`
     - `native/odbc_engine/MULTI_DATABASE_TESTING.md`
-

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -23,6 +23,10 @@ the engine provides `engine::core::DiskSpillStream`:
 This is wired into `odbc_stream_start` when `ODBC_STREAM_SPILL_THRESHOLD_MB` is set:
 buffer-mode streaming encodes via `DiskSpillWriter`; when data exceeds threshold,
 it spills to temp file and `StreamingStateFileBacked` reads in chunks.
+`DiskSpillWriter` writes full 64 KiB slices directly to the spill stream instead
+of allocating a temporary `Vec` per flush chunk. File-backed streaming opens the
+spill file once and advances sequentially for each `fetch_next_chunk`, avoiding
+per-chunk open/seek overhead.
 
 The FFI global state mutex is not held while streaming prepares, executes,
 reads cursor rows, or encodes/spills data. It is used only for lookup and stream

--- a/native/doc/data_paths.md
+++ b/native/doc/data_paths.md
@@ -24,6 +24,10 @@ This is wired into `odbc_stream_start` when `ODBC_STREAM_SPILL_THRESHOLD_MB` is 
 buffer-mode streaming encodes via `DiskSpillWriter`; when data exceeds threshold,
 it spills to temp file and `StreamingStateFileBacked` reads in chunks.
 
+The FFI global state mutex is not held while streaming prepares, executes,
+reads cursor rows, or encodes/spills data. It is used only for lookup and stream
+registration.
+
 ### 1.2 Caches and protocol negotiation (supporting utilities)
 
 These are supporting utilities that impact performance/compatibility:
@@ -43,6 +47,8 @@ FFI streaming (`odbc_stream_*`) has two modes:
 - Executes the query
 - Encodes the full result set into a `Vec<u8>`
 - Lets the caller pull it in fixed-size chunks via `odbc_stream_fetch`
+- If `ODBC_STREAM_SPILL_THRESHOLD_MB` is set, encoding goes through
+  `DiskSpillWriter` and may return a file-backed stream
 
 Use when: you need **bounded memory on the Dart side**, but can tolerate the engine holding the full result in memory.
 
@@ -83,8 +89,18 @@ does not apply the `BatchParam` values (placeholder for future parameter binding
 
 - `bulk_insert_i32(...)`
 - `bulk_insert_i32_text(...)`
+- `bulk_insert_generic(...)`
+- `bulk_insert_generic_range(...)` for pool workers that should operate on a
+  row range without cloning the entire payload chunk
 
 It uses an internal `paramset_size` (default: 1000) and sends rows in chunks.
+
+Bulk payload formats:
+
+- Legacy v1 remains accepted by Rust for compatibility.
+- v2 starts with `BLK2`, is the Dart default, and stores per-cell lengths for
+  text, decimal, and binary cells. This preserves embedded `0x00` bytes and
+  supports variable-width binary rows without padding.
 
 ### 4.1 Parallel bulk insert (pool + rayon + array binding)
 
@@ -94,6 +110,11 @@ It uses an internal `paramset_size` (default: 1000) and sends rows in chunks.
 - runs chunk inserts in parallel using `rayon`
 - each worker checks out a connection from `pool::ConnectionPool`
 - inserts via `engine::core::ArrayBinding`
+
+The FFI `odbc_bulk_insert_parallel` path uses row ranges over the original
+payload for ArrayBinding. When compiled with `sqlserver-bcp`, native BCP keeps
+an owned-chunk fallback because the BCP executor consumes a full
+`BulkInsertPayload`.
 
 ## 5) Connection pooling
 
@@ -185,5 +206,4 @@ These are implemented in Rust and used by the engine/FFI:
   - E2E tests may self-skip when no DSN is configured. See:
     - `native/odbc_engine/E2E_TESTS_ENV_CONFIG.md`
     - `native/odbc_engine/MULTI_DATABASE_TESTING.md`
-
 

--- a/native/doc/ffi_api.md
+++ b/native/doc/ffi_api.md
@@ -207,7 +207,7 @@ Closes all tracked prepared statements and clears statement state.
 
 - **Returns**: `0` on success; non-zero on failure.
 
-**Statement handle reuse (opt-in)**: Build with `--features statement-handle-reuse` to enable LRU prepared-statement reuse per connection. Current implementation caches prepared handles with explicit lifetime management; keep this feature opt-in until your workload benchmark confirms gains.
+**Statement handle reuse (opt-in)**: Build with `--features statement-handle-reuse` to enable LRU prepared-statement reuse per connection. This feature remains disabled by default. Without the feature, the prepared-statement cache/state is metadata and metrics only; it does not retain reusable ODBC statement handles. Keep the feature opt-in until your workload benchmark confirms gains.
 
 ## Streaming (chunked copy-out over FFI)
 
@@ -220,6 +220,9 @@ allocating a huge buffer on the Dart side.
    result, then yields fixed-size chunks. Bounded memory on the Dart side.
    When `ODBC_STREAM_SPILL_THRESHOLD_MB` is set (>0), large results spill to
    temp file; engine reads in chunks without holding full result in memory.
+   The global FFI state lock is used only for connection lookup and stream
+   registration, not while `prepare`, `execute`, cursor reads, or spill encoding
+   are running.
 
 2. **Batched mode** (`odbc_stream_start_batched`): Cursor-based batching. Fetches
    `fetch_size` rows per batch, encodes each batch, and stores only the next
@@ -639,6 +642,12 @@ Performs bulk insert on a regular connection. When feature `sqlserver-bcp` is en
 - **Data source**: current implementation reads table/columns/rows from `data_buffer`
   (serialized bulk payload); `table`/`columns`/`column_count`/`row_count` parameters are
   currently ignored by the Rust side.
+- **Wire format**: `data_buffer` may be legacy v1 or v2 (`BLK2`). v2 is the
+  Dart default and stores per-cell lengths for text/decimal/binary cells, so
+  binary values may contain embedded `0x00` bytes. Legacy v1 remains accepted
+  for compatibility.
+- **Locking**: connection lookup and error recording use global FFI state; ODBC
+  bulk execution runs outside the global mutex.
 
 ### `odbc_bulk_insert_parallel(pool_id, table, columns, column_count, data_buffer, buffer_len, parallelism, rows_inserted) -> int`
 
@@ -649,6 +658,10 @@ On partial failure, returns consolidated error with chunk indices and rows inser
 - **Returns**: `0` on success; `-1` on failure.
 - **parallelism** must be `>= 1`.
 - As above, table/column shape is taken from `data_buffer`.
+- **Chunking**: the default ArrayBinding path executes each worker over a row
+  range of the original payload to avoid cloning the chunk payload. With
+  `sqlserver-bcp`, the BCP executor still materializes an owned chunk per worker
+  because its API consumes a full `BulkInsertPayload`.
 
 ## Errors
 
@@ -797,5 +810,4 @@ if (caps != null && caps.driverName == 'PostgreSQL') {
   // Use SQL Server-specific patterns (e.g. TOP)
 }
 ```
-
 

--- a/native/doc/ffi_api.md
+++ b/native/doc/ffi_api.md
@@ -45,6 +45,8 @@ Creates a new ODBC connection and stores it in global state.
 
 - **Returns**: `conn_id > 0` on success; `0` on failure.
 - **Errors**: use `odbc_get_error(...)` / `odbc_get_structured_error(...)`.
+- **Locking**: global state is used to resolve/register handles; the ODBC
+  connection attempt runs outside the global mutex.
 
 ### `odbc_connect_with_timeout(conn_str: *const c_char, timeout_ms: unsigned int) -> unsigned int`
 
@@ -60,6 +62,8 @@ Disconnects and removes the connection. Also rolls back any active transactions
 belonging to that connection.
 
 - **Returns**: `0` on success; non‑zero on failure.
+- **Locking**: transaction rollback and driver disconnect run outside the global
+  mutex after the connection is removed from state.
 
 ## Audit logging
 
@@ -327,6 +331,8 @@ native.streamClose(streamId);
 
 Catalog functions use `INFORMATION_SCHEMA` (TABLES, COLUMNS) and return the same
 binary protocol as `odbc_exec_query`. Decode with `BinaryProtocolDecoder`.
+Connection lookup, cache lookup, and metrics/error writes use global state;
+metadata SQL execution runs outside the global mutex.
 
 ### Metadata cache controls
 
@@ -552,6 +558,8 @@ drive Phase 2 with `odbc_xa_commit_prepared` / `odbc_xa_rollback_prepared`.
 
 Savepoint operations run inside an active transaction and keep the transaction active.
 The SQL syntax depends on the `savepoint_dialect` passed to `odbc_transaction_begin`.
+The transaction handle is temporarily removed from global state while savepoint
+SQL executes, then reinserted after completion.
 
 ### `odbc_savepoint_create(txn_id, name) -> int`
 
@@ -584,6 +592,8 @@ Returns `pooled_conn_id > 0` on success; `0` on failure.
 Releases the checked-out pooled connection back to the pool. Before return, any active
 transaction is rolled back and autocommit is restored (RAII). Prepared statements for
 this connection are closed.
+Rollback/autocommit cleanup runs outside the global mutex; the pooled ID is
+recycled only after the wrapper is dropped back to r2d2.
 
 ### `odbc_pool_health_check(pool_id) -> int`
 
@@ -621,8 +631,9 @@ JSON format:
 
 Resizes the pool by recreating it with the new max size. All connections must be
 released before resize. Returns `0` on success; `-1` on error (invalid pool,
-connections checked out, or pool creation failed). r2d2 does not support in-place
-resize; the pool is recreated with the same connection string.
+connections checked out, active pooled FFI operations, or pool creation failed).
+r2d2 does not support in-place resize; the pool is recreated with the same
+connection string and the new pool is created outside the global mutex.
 
 ### `odbc_pool_close(pool_id) -> int`
 
@@ -630,6 +641,8 @@ Closes and removes the pool. Before close, any checked-out connections have thei
 active transactions rolled back and autocommit restored (RAII). Prepared statements
 for those connections are closed. Connections are then invalidated/removed from
 global state.
+Close is rejected while a pooled connection is temporarily busy in a long FFI
+call. Checked-out connection cleanup runs outside the global mutex.
 
 ## Bulk insert
 
@@ -810,4 +823,3 @@ if (caps != null && caps.driverName == 'PostgreSQL') {
   // Use SQL Server-specific patterns (e.g. TOP)
 }
 ```
-

--- a/native/doc/ffi_api.md
+++ b/native/doc/ffi_api.md
@@ -292,6 +292,10 @@ Fetches the next chunk. Works for both buffer and batched streams.
 - On success:
   - `out_written` is set to the bytes written for this chunk (may be `0` on EOF).
   - `out_has_more` is set to `1` if there is more, otherwise `0`.
+- If the function returns `-2`, the stream offset is not advanced; retry with a
+  larger buffer to receive the same chunk.
+- Chunks are copied directly into `out_buffer`; the FFI fetch path does not
+  allocate an intermediate chunk buffer.
 
 ### `odbc_stream_cancel(stream_id) -> int`
 

--- a/native/doc/performance_comparison.md
+++ b/native/doc/performance_comparison.md
@@ -45,6 +45,11 @@ xychart-beta
   with 4+ workers for large datasets. The default ArrayBinding path executes
   worker chunks by row range over the original payload, avoiding a full payload
   clone per worker.
+- **Streaming spill**: When `ODBC_STREAM_SPILL_THRESHOLD_MB` is enabled,
+  encoded chunks are written without per-chunk temporary allocation and
+  file-backed reads keep the spill file open across fetches. This reduces CPU
+  and filesystem overhead for large result sets without changing the wire
+  format.
 
 ### BCP (Bulk Copy)
 

--- a/native/doc/performance_comparison.md
+++ b/native/doc/performance_comparison.md
@@ -50,6 +50,10 @@ xychart-beta
   file-backed reads keep the spill file open across fetches. This reduces CPU
   and filesystem overhead for large result sets without changing the wire
   format.
+- **Protocol encoding**: Row-buffer, bulk payload, and multi-result encoders
+  pre-measure payload sizes before writing. This keeps large FFI payloads on a
+  single planned allocation path where possible and rejects impossible
+  multi-result lengths before emitting truncated length fields.
 
 ### BCP (Bulk Copy)
 

--- a/native/doc/performance_comparison.md
+++ b/native/doc/performance_comparison.md
@@ -54,6 +54,9 @@ xychart-beta
   pre-measure payload sizes before writing. This keeps large FFI payloads on a
   single planned allocation path where possible and rejects impossible
   multi-result lengths before emitting truncated length fields.
+- **Columnar/parameter paths**: Columnar v2 skips the temporary column payload
+  buffer when no compression is emitted, and parameter serialization builds the
+  full parameter list in one preallocated buffer.
 
 ### BCP (Bulk Copy)
 

--- a/native/doc/performance_comparison.md
+++ b/native/doc/performance_comparison.md
@@ -41,7 +41,10 @@ xychart-beta
 **Recommendations:**
 
 - **Array binding**: Single connection, batch sizes 500–2000. Best when parallelism is not needed.
-- **Parallel bulk**: Use `ParallelBulkInsert` with 4+ workers for large datasets. Scales well with row count.
+- **Parallel bulk**: Use `ParallelBulkInsert`/`odbc_bulk_insert_parallel`
+  with 4+ workers for large datasets. The default ArrayBinding path executes
+  worker chunks by row range over the original payload, avoiding a full payload
+  clone per worker.
 
 ### BCP (Bulk Copy)
 
@@ -66,6 +69,9 @@ xychart-beta
 
 - Use **native BCP** when `sqlncli11.dll` is available and bulk insert volume is high (10k+ rows).
 - Fallback to **ArrayBinding** automatically when native BCP is unavailable or disabled.
+- In parallel mode with `sqlserver-bcp`, BCP still materializes an owned payload
+  per chunk because the BCP executor consumes `BulkInsertPayload`; this is the
+  documented fallback when range/view execution is unavailable.
 
 ---
 
@@ -119,13 +125,19 @@ xychart-beta
 **Recommendations:**
 
 - Use **streaming** for large result sets to reduce memory and improve latency.
+  `odbc_stream_start` no longer holds the global FFI state lock while executing
+  or encoding; for bounded Rust-side memory prefer batched streaming or set
+  `ODBC_STREAM_SPILL_THRESHOLD_MB` for file-backed buffer-mode streaming.
 - Cold vs warm difference is small; metadata cache helps repeated catalog queries more than simple SELECTs.
 
 ---
 
 ## Statement Reuse (Repetitive Queries)
 
-Feature flag `statement-handle-reuse` implements real prepared statement handle reuse using type-erased caching with explicit lifetime management.
+Feature flag `statement-handle-reuse` implements real prepared statement handle
+reuse using type-erased caching with explicit lifetime management. It is
+disabled by default; without the feature, cache counters/metadata do not
+represent reusable ODBC statement handles.
 
 **Status (2026-03-10):**
 - Implementation complete with unsafe lifetime extension and guaranteed drop order safety.

--- a/native/doc/performance_comparison.md
+++ b/native/doc/performance_comparison.md
@@ -47,9 +47,10 @@ xychart-beta
   clone per worker.
 - **Streaming spill**: When `ODBC_STREAM_SPILL_THRESHOLD_MB` is enabled,
   encoded chunks are written without per-chunk temporary allocation and
-  file-backed reads keep the spill file open across fetches. This reduces CPU
-  and filesystem overhead for large result sets without changing the wire
-  format.
+  file-backed reads keep the spill file open across fetches. FFI stream fetch
+  writes directly into the caller buffer, avoiding an intermediate chunk `Vec`
+  allocation on every fetch. This reduces CPU and filesystem overhead for large
+  result sets without changing the wire format.
 - **Protocol encoding**: Row-buffer, bulk payload, and multi-result encoders
   pre-measure payload sizes before writing. This keeps large FFI payloads on a
   single planned allocation path where possible and rejects impossible

--- a/native/odbc_engine/src/engine/cell_reader.rs
+++ b/native/odbc_engine/src/engine/cell_reader.rs
@@ -74,7 +74,10 @@ impl CellReader {
             .map_err(OdbcError::from)?;
 
         if has_value {
-            Ok(Some(std::mem::take(&mut self.binary_buf)))
+            let mut out = Vec::new();
+            std::mem::swap(&mut out, &mut self.binary_buf);
+            self.binary_buf = Vec::with_capacity(out.capacity());
+            Ok(Some(out))
         } else {
             Ok(None)
         }

--- a/native/odbc_engine/src/engine/core/array_binding.rs
+++ b/native/odbc_engine/src/engine/core/array_binding.rs
@@ -6,7 +6,6 @@ use crate::protocol::bulk_insert::{
 use odbc_api::handles::AsStatementRef;
 use odbc_api::sys::NULL_DATA;
 use odbc_api::{buffers::BufferDesc, Connection};
-use std::iter::once;
 
 /// Validate and quote each `&str` in `columns`, returning a comma-separated
 /// list ready to inject into a SQL `INSERT (...)` clause.
@@ -14,11 +13,25 @@ use std::iter::once;
 /// A2 fix: every column identifier passes through `quote_identifier_default`
 /// before reaching the wire, eliminating SQL injection vectors.
 fn quote_column_list(columns: &[&str]) -> Result<String> {
-    let mut quoted = Vec::with_capacity(columns.len());
-    for c in columns {
-        quoted.push(quote_identifier_default(c)?);
+    let mut out = String::with_capacity(columns.len().saturating_mul(8));
+    for (idx, c) in columns.iter().enumerate() {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        out.push_str(&quote_identifier_default(c)?);
     }
-    Ok(quoted.join(", "))
+    Ok(out)
+}
+
+fn placeholders(n_cols: usize) -> String {
+    let mut out = String::with_capacity(n_cols.saturating_mul(3).saturating_sub(2));
+    for idx in 0..n_cols {
+        if idx > 0 {
+            out.push_str(", ");
+        }
+        out.push('?');
+    }
+    out
 }
 
 const DEFAULT_PARAMSET_SIZE: usize = 1000;
@@ -76,11 +89,7 @@ impl ArrayBinding {
             return Ok(0);
         }
 
-        let placeholders = once("?")
-            .cycle()
-            .take(n_cols)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let placeholders = placeholders(n_cols);
         let col_list = quote_column_list(columns)?;
         let qtable = quote_qualified_default(table)?;
         let sql = format!("INSERT INTO {qtable} ({col_list}) VALUES ({placeholders})");
@@ -213,16 +222,14 @@ impl ArrayBinding {
             ));
         }
 
-        let mut quoted_cols = Vec::with_capacity(payload.columns.len());
-        for s in &payload.columns {
-            quoted_cols.push(quote_identifier_default(&s.name)?);
+        let mut col_list = String::with_capacity(payload.columns.len().saturating_mul(8));
+        for (idx, s) in payload.columns.iter().enumerate() {
+            if idx > 0 {
+                col_list.push_str(", ");
+            }
+            col_list.push_str(&quote_identifier_default(&s.name)?);
         }
-        let col_list = quoted_cols.join(", ");
-        let placeholders = once("?")
-            .cycle()
-            .take(n_cols)
-            .collect::<Vec<_>>()
-            .join(", ");
+        let placeholders = placeholders(n_cols);
         let qtable = quote_qualified_default(&payload.table)?;
         let sql = format!("INSERT INTO {qtable} ({col_list}) VALUES ({placeholders})");
 
@@ -519,5 +526,12 @@ mod tests {
     fn test_array_binding_min_size_one() {
         let ab = ArrayBinding::new(0);
         assert_eq!(ab.paramset_size(), 1);
+    }
+
+    #[test]
+    fn test_placeholders_builds_without_extra_separator() {
+        assert_eq!(placeholders(0), "");
+        assert_eq!(placeholders(1), "?");
+        assert_eq!(placeholders(3), "?, ?, ?");
     }
 }

--- a/native/odbc_engine/src/engine/core/array_binding.rs
+++ b/native/odbc_engine/src/engine/core/array_binding.rs
@@ -185,7 +185,24 @@ impl ArrayBinding {
         conn: &Connection<'static>,
         payload: &BulkInsertPayload,
     ) -> Result<usize> {
-        let n_rows = payload.row_count as usize;
+        self.bulk_insert_generic_range(conn, payload, 0, payload.row_count as usize)
+    }
+
+    pub fn bulk_insert_generic_range(
+        &self,
+        conn: &Connection<'static>,
+        payload: &BulkInsertPayload,
+        start: usize,
+        end: usize,
+    ) -> Result<usize> {
+        let total_rows = payload.row_count as usize;
+        if start > end || end > total_rows {
+            return Err(OdbcError::ValidationError(
+                "Invalid bulk insert range".to_string(),
+            ));
+        }
+
+        let n_rows = end - start;
         if n_rows == 0 {
             return Ok(0);
         }
@@ -222,9 +239,9 @@ impl ArrayBinding {
             .map_err(OdbcError::from)?;
 
         let mut total = 0_usize;
-        for chunk_start in (0..n_rows).step_by(capacity) {
-            let end = (chunk_start + capacity).min(n_rows);
-            let chunk_len = end - chunk_start;
+        for chunk_start in (start..end).step_by(capacity) {
+            let chunk_end = (chunk_start + capacity).min(end);
+            let chunk_len = chunk_end - chunk_start;
             inserter.set_num_rows(chunk_len);
 
             for (buf_idx, (spec, data)) in payload

--- a/native/odbc_engine/src/engine/core/disk_spill.rs
+++ b/native/odbc_engine/src/engine/core/disk_spill.rs
@@ -23,23 +23,44 @@ impl<'a> DiskSpillWriter<'a> {
 }
 
 impl Write for DiskSpillWriter<'_> {
-    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
-        self.buffer.extend_from_slice(buf);
-        while self.buffer.len() >= WRITE_CHUNK_SIZE {
-            let chunk: Vec<u8> = self.buffer.drain(..WRITE_CHUNK_SIZE).collect();
-            self.spill
-                .write_chunk(&chunk)
-                .map_err(std::io::Error::other)?;
+    fn write(&mut self, mut buf: &[u8]) -> std::io::Result<usize> {
+        let written = buf.len();
+
+        if !self.buffer.is_empty() {
+            let remaining = WRITE_CHUNK_SIZE - self.buffer.len();
+            let to_buffer = remaining.min(buf.len());
+            self.buffer.extend_from_slice(&buf[..to_buffer]);
+            buf = &buf[to_buffer..];
+
+            if self.buffer.len() == WRITE_CHUNK_SIZE {
+                self.spill
+                    .write_chunk(&self.buffer)
+                    .map_err(std::io::Error::other)?;
+                self.buffer.clear();
+            }
         }
-        Ok(buf.len())
+
+        while buf.len() >= WRITE_CHUNK_SIZE {
+            let (chunk, rest) = buf.split_at(WRITE_CHUNK_SIZE);
+            self.spill
+                .write_chunk(chunk)
+                .map_err(std::io::Error::other)?;
+            buf = rest;
+        }
+
+        if !buf.is_empty() {
+            self.buffer.extend_from_slice(buf);
+        }
+
+        Ok(written)
     }
 
     fn flush(&mut self) -> std::io::Result<()> {
         if !self.buffer.is_empty() {
-            let chunk = std::mem::take(&mut self.buffer);
             self.spill
-                .write_chunk(&chunk)
+                .write_chunk(&self.buffer)
                 .map_err(std::io::Error::other)?;
+            self.buffer.clear();
         }
         Ok(())
     }
@@ -216,5 +237,22 @@ mod tests {
         let out = s.read_back().unwrap();
         assert_eq!(out.len(), 1 + 2 * 1024 * 1024);
         assert_eq!(out[0], 42);
+    }
+
+    #[test]
+    fn test_disk_spill_writer_large_write_roundtrip() {
+        let mut s = DiskSpillStream::new(1);
+        let input: Vec<u8> = (0..(WRITE_CHUNK_SIZE * 3 + 17))
+            .map(|n| (n % 251) as u8)
+            .collect();
+
+        {
+            let mut writer = DiskSpillWriter::new(&mut s);
+            writer.write_all(&input).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let out = s.read_back().unwrap();
+        assert_eq!(out, input);
     }
 }

--- a/native/odbc_engine/src/engine/mod.rs
+++ b/native/odbc_engine/src/engine/mod.rs
@@ -45,7 +45,7 @@ pub use sqlserver_json::{
 pub use statement::StatementHandle;
 pub use streaming::{
     start_multi_async_stream, start_multi_batched_stream, AsyncStreamStatus, AsyncStreamingState,
-    BatchedStreamingState, StreamState, StreamingExecutor, StreamingState,
+    BatchedStreamingState, StreamCopyResult, StreamState, StreamingExecutor, StreamingState,
     MULTI_STREAM_ITEM_TAG_RESULT_SET, MULTI_STREAM_ITEM_TAG_ROW_COUNT,
 };
 pub use transaction::{

--- a/native/odbc_engine/src/engine/streaming.rs
+++ b/native/odbc_engine/src/engine/streaming.rs
@@ -7,7 +7,7 @@ use crate::protocol::{OdbcType, RowBuffer, RowBufferEncoder};
 use odbc_api::handles::{AsStatementRef, SqlResult, Statement};
 use odbc_api::{Connection, Cursor, CursorImpl, ResultSetMetadata};
 use std::fs::File;
-use std::io::{Read, Seek, SeekFrom, Write};
+use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc;
@@ -179,12 +179,9 @@ impl StreamingExecutor {
                         let total_len = std::fs::metadata(&path)
                             .map(|m| m.len() as usize)
                             .unwrap_or(0);
-                        Ok(StreamState::FileBacked(StreamingStateFileBacked {
-                            path,
-                            offset: 0,
-                            chunk_size,
-                            total_len,
-                        }))
+                        Ok(StreamState::FileBacked(StreamingStateFileBacked::new(
+                            path, chunk_size, total_len,
+                        )?))
                     }
                     crate::engine::core::SpillReadSource::Memory(data) => {
                         Ok(StreamState::InMemory(StreamingState {
@@ -1030,28 +1027,39 @@ impl StreamState {
 /// Streaming state backed by a temp file. Reads in chunks; deletes file on drop.
 pub struct StreamingStateFileBacked {
     path: PathBuf,
+    file: Option<File>,
     offset: usize,
     chunk_size: usize,
     total_len: usize,
 }
 
 impl StreamingStateFileBacked {
+    fn new(path: PathBuf, chunk_size: usize, total_len: usize) -> Result<Self> {
+        let file = File::open(&path)
+            .map_err(|e| OdbcError::InternalError(format!("spill file open: {}", e)))?;
+        Ok(Self {
+            path,
+            file: Some(file),
+            offset: 0,
+            chunk_size,
+            total_len,
+        })
+    }
+
     pub fn fetch_next_chunk(&mut self) -> Result<Option<Vec<u8>>> {
         if self.offset >= self.total_len {
             return Ok(None);
         }
-
-        let mut f = File::open(&self.path)
-            .map_err(|e| OdbcError::InternalError(format!("spill file read: {}", e)))?;
-        f.seek(SeekFrom::Start(self.offset as u64))
-            .map_err(|e| OdbcError::InternalError(format!("spill file seek: {}", e)))?;
 
         let to_read = (self.chunk_size).min(self.total_len - self.offset);
         let mut buf = vec![0u8; to_read];
         // A6 fix: a single `read()` may return fewer bytes than requested
         // (especially on Windows for files >64 KiB). Use `read_exact` so the
         // caller never observes a short chunk silently.
-        f.read_exact(&mut buf)
+        self.file
+            .as_mut()
+            .ok_or_else(|| OdbcError::InternalError("spill file already closed".to_string()))?
+            .read_exact(&mut buf)
             .map_err(|e| OdbcError::InternalError(format!("spill file read_exact: {}", e)))?;
         self.offset += to_read;
 
@@ -1069,6 +1077,7 @@ impl StreamingStateFileBacked {
 
 impl Drop for StreamingStateFileBacked {
     fn drop(&mut self) {
+        drop(self.file.take());
         let _ = std::fs::remove_file(&self.path);
     }
 }
@@ -1320,6 +1329,29 @@ mod tests {
         let chunk2 = state.fetch_next_chunk().unwrap();
         assert_eq!(chunk2, None);
         assert_eq!(state.offset, 3);
+    }
+
+    #[test]
+    fn test_file_backed_streaming_state_keeps_file_open_and_cleans_up() {
+        let path = std::env::temp_dir().join(format!(
+            "odbc_streaming_state_test_{}.bin",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, [1u8, 2, 3, 4, 5, 6, 7]).unwrap();
+
+        {
+            let mut state = StreamingStateFileBacked::new(path.clone(), 3, 7).unwrap();
+
+            assert_eq!(state.fetch_next_chunk().unwrap(), Some(vec![1, 2, 3]));
+            assert_eq!(state.fetch_next_chunk().unwrap(), Some(vec![4, 5, 6]));
+            assert_eq!(state.fetch_next_chunk().unwrap(), Some(vec![7]));
+            assert_eq!(state.fetch_next_chunk().unwrap(), None);
+        }
+
+        assert!(!path.exists(), "file-backed stream should remove temp file");
     }
 
     #[test]

--- a/native/odbc_engine/src/engine/streaming.rs
+++ b/native/odbc_engine/src/engine/streaming.rs
@@ -44,6 +44,13 @@ pub enum AsyncStreamStatus {
     Error,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamCopyResult {
+    Copied { written: usize, has_more: bool },
+    End,
+    BufferTooSmall { needed: usize },
+}
+
 impl StreamingExecutor {
     pub fn new(chunk_size: usize) -> Self {
         Self { chunk_size }
@@ -834,6 +841,67 @@ impl BatchedStreamingState {
         Ok(Some(chunk))
     }
 
+    pub fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
+        if let Some(ref msg) = self.stream_error {
+            return Err(OdbcError::InternalError(msg.clone()));
+        }
+        if self.done {
+            return Ok(StreamCopyResult::End);
+        }
+
+        let batch_len = self.current_batch.as_ref().map_or(0, Vec::len);
+        if self.current_batch.is_none() || self.offset >= batch_len {
+            match self.receiver.recv() {
+                Ok(BatchedMessage::Batch(b)) => {
+                    self.current_batch = Some(b);
+                    self.offset = 0;
+                }
+                Ok(BatchedMessage::Done) => {
+                    self.done = true;
+                    return Ok(StreamCopyResult::End);
+                }
+                Ok(BatchedMessage::Cancelled) => {
+                    self.done = true;
+                    self.cancelled = true;
+                    return Ok(StreamCopyResult::End);
+                }
+                Ok(BatchedMessage::Error(m)) => {
+                    self.stream_error = Some(m.clone());
+                    return Err(OdbcError::InternalError(m));
+                }
+                Err(disc_err) => {
+                    self.done = true;
+                    let msg = format!("Stream worker disconnected unexpectedly: {disc_err}");
+                    self.stream_error = Some(msg.clone());
+                    return Err(OdbcError::WorkerCrashed(msg));
+                }
+            }
+        }
+
+        let batch = self.current_batch.as_ref().ok_or_else(|| {
+            OdbcError::InternalError(
+                "Streaming state corrupted: no batch available after receiver processing"
+                    .to_string(),
+            )
+        })?;
+        let end = self.offset.saturating_add(self.chunk_size).min(batch.len());
+        let needed = end - self.offset;
+        if out.len() < needed {
+            return Ok(StreamCopyResult::BufferTooSmall { needed });
+        }
+
+        out[..needed].copy_from_slice(&batch[self.offset..end]);
+        self.offset = end;
+        if self.offset >= batch.len() {
+            self.current_batch = None;
+            self.offset = 0;
+        }
+        Ok(StreamCopyResult::Copied {
+            written: needed,
+            has_more: self.has_more(),
+        })
+    }
+
     pub fn has_more(&self) -> bool {
         !self.done
     }
@@ -982,6 +1050,67 @@ impl AsyncStreamingState {
         Ok(Some(chunk))
     }
 
+    pub fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
+        if let Some(ref msg) = self.stream_error {
+            return Err(OdbcError::InternalError(msg.clone()));
+        }
+        if self.done {
+            return Ok(StreamCopyResult::End);
+        }
+
+        let batch_len = self.current_batch_len();
+        if self.current_batch.is_none() || self.offset >= batch_len {
+            match self.receiver.recv() {
+                Ok(BatchedMessage::Batch(b)) => {
+                    self.current_batch = Some(b);
+                    self.offset = 0;
+                }
+                Ok(BatchedMessage::Done) => {
+                    self.done = true;
+                    return Ok(StreamCopyResult::End);
+                }
+                Ok(BatchedMessage::Cancelled) => {
+                    self.done = true;
+                    self.cancelled = true;
+                    return Ok(StreamCopyResult::End);
+                }
+                Ok(BatchedMessage::Error(m)) => {
+                    self.stream_error = Some(m.clone());
+                    return Err(OdbcError::InternalError(m));
+                }
+                Err(disc_err) => {
+                    self.done = true;
+                    let msg = format!("Async stream worker disconnected unexpectedly: {disc_err}");
+                    self.stream_error = Some(msg.clone());
+                    return Err(OdbcError::WorkerCrashed(msg));
+                }
+            }
+        }
+
+        let batch = self.current_batch.as_ref().ok_or_else(|| {
+            OdbcError::InternalError(
+                "Async stream state corrupted: no batch available after receiver processing"
+                    .to_string(),
+            )
+        })?;
+        let end = self.offset.saturating_add(self.chunk_size).min(batch.len());
+        let needed = end - self.offset;
+        if out.len() < needed {
+            return Ok(StreamCopyResult::BufferTooSmall { needed });
+        }
+
+        out[..needed].copy_from_slice(&batch[self.offset..end]);
+        self.offset = end;
+        if self.offset >= batch.len() {
+            self.current_batch = None;
+            self.offset = 0;
+        }
+        Ok(StreamCopyResult::Copied {
+            written: needed,
+            has_more: self.has_more(),
+        })
+    }
+
     pub fn has_more(&self) -> bool {
         !self.done
     }
@@ -1020,6 +1149,13 @@ impl StreamState {
         match self {
             StreamState::InMemory(s) => s.has_more(),
             StreamState::FileBacked(s) => s.has_more(),
+        }
+    }
+
+    pub fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
+        match self {
+            StreamState::InMemory(s) => s.copy_next_chunk(out),
+            StreamState::FileBacked(s) => s.copy_next_chunk(out),
         }
     }
 }
@@ -1070,6 +1206,29 @@ impl StreamingStateFileBacked {
         }
     }
 
+    pub fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
+        if self.offset >= self.total_len {
+            return Ok(StreamCopyResult::End);
+        }
+
+        let to_read = self.chunk_size.min(self.total_len - self.offset);
+        if out.len() < to_read {
+            return Ok(StreamCopyResult::BufferTooSmall { needed: to_read });
+        }
+
+        self.file
+            .as_mut()
+            .ok_or_else(|| OdbcError::InternalError("spill file already closed".to_string()))?
+            .read_exact(&mut out[..to_read])
+            .map_err(|e| OdbcError::InternalError(format!("spill file read_exact: {}", e)))?;
+        self.offset += to_read;
+
+        Ok(StreamCopyResult::Copied {
+            written: to_read,
+            has_more: self.has_more(),
+        })
+    }
+
     pub fn has_more(&self) -> bool {
         self.offset < self.total_len
     }
@@ -1099,6 +1258,28 @@ impl StreamingState {
         self.offset = end;
 
         Ok(Some(chunk))
+    }
+
+    pub fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
+        if self.offset >= self.data.len() {
+            return Ok(StreamCopyResult::End);
+        }
+
+        let end = self
+            .offset
+            .saturating_add(self.chunk_size)
+            .min(self.data.len());
+        let needed = end - self.offset;
+        if out.len() < needed {
+            return Ok(StreamCopyResult::BufferTooSmall { needed });
+        }
+
+        out[..needed].copy_from_slice(&self.data[self.offset..end]);
+        self.offset = end;
+        Ok(StreamCopyResult::Copied {
+            written: needed,
+            has_more: self.has_more(),
+        })
     }
 
     pub fn has_more(&self) -> bool {
@@ -1149,6 +1330,31 @@ mod tests {
         assert_eq!(chunk, Some(vec![1, 2, 3]));
         assert!(state.current_batch.is_none());
         assert_eq!(state.fetch_next_chunk().unwrap(), None);
+    }
+
+    #[test]
+    fn test_batched_streaming_state_copy_preserves_offset_when_buffer_too_small() {
+        let (tx, rx) = mpsc::sync_channel::<BatchedMessage>(2);
+        let _ = tx.send(BatchedMessage::Batch(vec![1, 2, 3, 4]));
+        let _ = tx.send(BatchedMessage::Done);
+        drop(tx);
+
+        let mut state = BatchedStreamingState::from_receiver(rx, 3);
+        let mut tiny = [0u8; 2];
+        assert_eq!(
+            state.copy_next_chunk(&mut tiny).unwrap(),
+            StreamCopyResult::BufferTooSmall { needed: 3 }
+        );
+
+        let mut out = [0u8; 3];
+        assert_eq!(
+            state.copy_next_chunk(&mut out).unwrap(),
+            StreamCopyResult::Copied {
+                written: 3,
+                has_more: true
+            }
+        );
+        assert_eq!(&out, &[1, 2, 3]);
     }
 
     #[test]
@@ -1314,6 +1520,34 @@ mod tests {
     }
 
     #[test]
+    fn test_streaming_state_copy_next_chunk_writes_without_advancing_on_small_buffer() {
+        let data = vec![1, 2, 3, 4, 5];
+        let mut state = StreamingState {
+            data,
+            offset: 0,
+            chunk_size: 4,
+        };
+
+        let mut tiny = [0u8; 3];
+        assert_eq!(
+            state.copy_next_chunk(&mut tiny).unwrap(),
+            StreamCopyResult::BufferTooSmall { needed: 4 }
+        );
+        assert_eq!(state.offset, 0);
+
+        let mut out = [0u8; 4];
+        assert_eq!(
+            state.copy_next_chunk(&mut out).unwrap(),
+            StreamCopyResult::Copied {
+                written: 4,
+                has_more: true
+            }
+        );
+        assert_eq!(&out, &[1, 2, 3, 4]);
+        assert_eq!(state.offset, 4);
+    }
+
+    #[test]
     fn test_streaming_state_fetch_next_chunk_returns_none_when_exhausted() {
         let data = vec![1, 2, 3];
         let mut state = StreamingState {
@@ -1349,6 +1583,39 @@ mod tests {
             assert_eq!(state.fetch_next_chunk().unwrap(), Some(vec![4, 5, 6]));
             assert_eq!(state.fetch_next_chunk().unwrap(), Some(vec![7]));
             assert_eq!(state.fetch_next_chunk().unwrap(), None);
+        }
+
+        assert!(!path.exists(), "file-backed stream should remove temp file");
+    }
+
+    #[test]
+    fn test_file_backed_streaming_state_copy_preserves_offset_when_buffer_too_small() {
+        let path = std::env::temp_dir().join(format!(
+            "odbc_streaming_state_copy_test_{}.bin",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::write(&path, [9u8, 8, 7, 6]).unwrap();
+
+        {
+            let mut state = StreamingStateFileBacked::new(path.clone(), 3, 4).unwrap();
+            let mut tiny = [0u8; 2];
+            assert_eq!(
+                state.copy_next_chunk(&mut tiny).unwrap(),
+                StreamCopyResult::BufferTooSmall { needed: 3 }
+            );
+
+            let mut out = [0u8; 3];
+            assert_eq!(
+                state.copy_next_chunk(&mut out).unwrap(),
+                StreamCopyResult::Copied {
+                    written: 3,
+                    has_more: true
+                }
+            );
+            assert_eq!(&out, &[9, 8, 7]);
         }
 
         assert!(!path.exists(), "file-backed stream should remove temp file");

--- a/native/odbc_engine/src/engine/streaming.rs
+++ b/native/odbc_engine/src/engine/streaming.rs
@@ -1225,6 +1225,60 @@ mod tests {
     }
 
     #[test]
+    fn test_streaming_spill_writer_matches_row_buffer_encoder() {
+        let mut buffer = RowBuffer::new();
+        buffer.add_column("id".to_string(), OdbcType::Integer);
+        buffer.add_column("name".to_string(), OdbcType::Varchar);
+        buffer.add_row(vec![
+            Some(1i32.to_le_bytes().to_vec()),
+            Some(b"one".to_vec()),
+        ]);
+        buffer.add_row(vec![Some(2i32.to_le_bytes().to_vec()), None]);
+
+        let expected = RowBufferEncoder::encode(&buffer);
+        let mut spill = DiskSpillStream::new(1);
+        {
+            let mut writer = DiskSpillWriter::new(&mut spill);
+            RowBufferEncoder::encode_to_writer(&buffer, &mut writer).unwrap();
+            writer.flush().unwrap();
+        }
+        let actual = spill.read_back().unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn test_streaming_spill_threshold_file_backed_matches_encoder() {
+        let mut buffer = RowBuffer::new();
+        buffer.add_column("payload".to_string(), OdbcType::Binary);
+        buffer.add_row(vec![Some(vec![42u8; 1024 * 1024 + 128])]);
+
+        let expected = RowBufferEncoder::encode(&buffer);
+        let mut spill = DiskSpillStream::new(1);
+        {
+            let mut writer = DiskSpillWriter::new(&mut spill);
+            RowBufferEncoder::encode_to_writer(&buffer, &mut writer).unwrap();
+            writer.flush().unwrap();
+        }
+
+        let source = spill.finish_for_streaming_read().unwrap();
+        let actual = match source {
+            crate::engine::core::SpillReadSource::File(path) => {
+                let bytes = std::fs::read(&path).unwrap();
+                let _ = std::fs::remove_file(path);
+                bytes
+            }
+            crate::engine::core::SpillReadSource::Memory(bytes) => bytes,
+        };
+
+        assert_eq!(actual, expected);
+        assert!(
+            actual.len() > 1024 * 1024,
+            "test must exercise the low-threshold spill path"
+        );
+    }
+
+    #[test]
     fn test_streaming_state_fetch_next_chunk() {
         let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         let mut state = StreamingState {

--- a/native/odbc_engine/src/ffi/mod.rs
+++ b/native/odbc_engine/src/ffi/mod.rs
@@ -17,8 +17,8 @@ use crate::engine::{
     list_foreign_keys, list_indexes, list_primary_keys, list_tables, recover_prepared_xids,
     resume_prepared, AsyncStreamStatus, AsyncStreamingState, BatchedStreamingState,
     DriverCapabilities, IsolationLevel, LockTimeout, MetadataCache, OdbcConnection,
-    OdbcEnvironment, PreparedXa, PreparingXa, SavepointDialect, StatementHandle, StreamState,
-    StreamingExecutor, Transaction, TransactionAccessMode, XaTransaction, Xid,
+    OdbcEnvironment, PreparedXa, PreparingXa, SavepointDialect, StatementHandle, StreamCopyResult,
+    StreamState, StreamingExecutor, Transaction, TransactionAccessMode, XaTransaction, Xid,
 };
 use crate::error::StructuredError;
 use crate::error::{OdbcError, Result};
@@ -70,19 +70,11 @@ enum StreamKind {
 }
 
 impl StreamKind {
-    fn fetch_next_chunk(&mut self) -> Result<Option<Vec<u8>>> {
+    fn copy_next_chunk(&mut self, out: &mut [u8]) -> Result<StreamCopyResult> {
         match self {
-            StreamKind::Buffer(s) => s.fetch_next_chunk(),
-            StreamKind::Batched(s) => s.fetch_next_chunk(),
-            StreamKind::AsyncBatched(s) => s.fetch_next_chunk(),
-        }
-    }
-
-    fn has_more(&self) -> bool {
-        match self {
-            StreamKind::Buffer(s) => s.has_more(),
-            StreamKind::Batched(s) => s.has_more(),
-            StreamKind::AsyncBatched(s) => s.has_more(),
+            StreamKind::Buffer(s) => s.copy_next_chunk(out),
+            StreamKind::Batched(s) => s.copy_next_chunk(out),
+            StreamKind::AsyncBatched(s) => s.copy_next_chunk(out),
         }
     }
 
@@ -486,7 +478,6 @@ struct GlobalState {
     statements: HashMap<u32, StatementHandle>,
     streams: HashMap<u32, StreamKind>,
     stream_connections: HashMap<u32, u32>, // Map stream_id -> conn_id
-    pending_stream_chunks: HashMap<u32, PendingStreamChunk>,
     pending_result_buffers: HashMap<PendingResultKey, PendingResultBuffer>,
     pools: HashMap<u32, Arc<ConnectionPool>>,
     pooled_connections: HashMap<u32, (u32, PooledConnectionWrapper)>, // pooled_conn_id -> (pool_id, wrapper)
@@ -510,11 +501,6 @@ struct GlobalState {
     metadata_cache: MetadataCache,
     metrics: Arc<Metrics>,
     audit_logger: Arc<AuditLogger>,
-}
-
-struct PendingStreamChunk {
-    data: Vec<u8>,
-    has_more: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -664,7 +650,6 @@ fn get_global_state() -> &'static Arc<Mutex<GlobalState>> {
             statements: HashMap::new(),
             streams: HashMap::new(),
             stream_connections: HashMap::new(),
-            pending_stream_chunks: HashMap::new(),
             pending_result_buffers: HashMap::new(),
             pools: HashMap::new(),
             pooled_connections: HashMap::new(),
@@ -1200,7 +1185,6 @@ pub extern "C" fn odbc_disconnect(conn_id: c_uint) -> c_int {
                     stream.cancel();
                 }
                 state.stream_connections.remove(&stream_id);
-                state.pending_stream_chunks.remove(&stream_id);
             }
             state.async_requests.free_for_connection(conn_id);
             state.pending_result_buffers.retain(|key, _| match key {
@@ -4865,60 +4849,6 @@ pub extern "C" fn odbc_stream_fetch(
 
         let stream_conn_id = state.stream_connections.get(&stream_id).copied();
 
-        if let Some(needed_len) = state
-            .pending_stream_chunks
-            .get(&stream_id)
-            .map(|pending| pending.data.len())
-        {
-            if needed_len > buf_len as usize {
-                if let Some(conn_id) = stream_conn_id {
-                    set_connection_error(
-                        &mut state,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            needed_len, buf_len
-                        ),
-                    );
-                } else {
-                    set_error(
-                        &mut state,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            needed_len, buf_len
-                        ),
-                    );
-                }
-                return -2;
-            }
-
-            let pending = match state.pending_stream_chunks.remove(&stream_id) {
-                Some(p) => p,
-                None => {
-                    // Race: chunk vanished between length check and removal. Treat as
-                    // an internal-state error rather than panicking across the FFI.
-                    set_error(
-                        &mut state,
-                        format!("Stream {} pending chunk vanished concurrently", stream_id),
-                    );
-                    return -1;
-                }
-            };
-            // Keep has_more from the original fetch that produced this chunk.
-            // This preserves stream semantics across buffer-resize retries.
-            let has_more_value = pending.has_more;
-            let written_len = pending.data.len();
-            // SAFETY: `out_buf` was checked non-null and `buf_len` covers `written_len`
-            // (verified above against `needed_len`). `out_written`/`has_more` were
-            // checked non-null at function entry.
-            unsafe {
-                std::ptr::copy_nonoverlapping(pending.data.as_ptr(), out_buf, written_len);
-                *out_written = written_len as c_uint;
-                *has_more = if has_more_value { 1 } else { 0 };
-            }
-            return 0;
-        }
-
         let mut stream = match state.streams.remove(&stream_id) {
             Some(s) => s,
             None => {
@@ -4928,8 +4858,8 @@ pub extern "C" fn odbc_stream_fetch(
         };
         drop(state);
 
-        let fetch_result = stream.fetch_next_chunk();
-        let has_more_after_fetch = stream.has_more();
+        let out_slice = unsafe { std::slice::from_raw_parts_mut(out_buf, buf_len as usize) };
+        let fetch_result = stream.copy_next_chunk(out_slice);
 
         let Some(mut state) = try_lock_global_state() else {
             return -1;
@@ -4937,43 +4867,33 @@ pub extern "C" fn odbc_stream_fetch(
         state.streams.insert(stream_id, stream);
 
         match fetch_result {
-            Ok(Some(data)) => {
-                let has_more_value = has_more_after_fetch;
-                let data_len = data.len();
-                if data.len() > buf_len as usize {
-                    state.pending_stream_chunks.insert(
-                        stream_id,
-                        PendingStreamChunk {
-                            data,
-                            has_more: has_more_value,
-                        },
-                    );
-                    if let Some(conn_id) = stream_conn_id {
-                        set_connection_error(
-                            &mut state,
-                            conn_id,
-                            format!("Buffer too small: need {} bytes, got {}", data_len, buf_len),
-                        );
-                    } else {
-                        set_error(
-                            &mut state,
-                            format!("Buffer too small: need {} bytes, got {}", data_len, buf_len),
-                        );
-                    }
-                    return -2;
-                }
-
-                // Safety: Pointers must be valid for their respective writes
-                // out_buf: data.len() bytes, out_written/has_more: respective sizes
+            Ok(StreamCopyResult::Copied {
+                written,
+                has_more: more,
+            }) => {
                 unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buf, data.len());
-                    *out_written = data.len() as c_uint;
-                    *has_more = if has_more_value { 1 } else { 0 };
+                    *out_written = written as c_uint;
+                    *has_more = if more { 1 } else { 0 };
                 }
 
                 0
             }
-            Ok(None) => {
+            Ok(StreamCopyResult::BufferTooSmall { needed }) => {
+                if let Some(conn_id) = stream_conn_id {
+                    set_connection_error(
+                        &mut state,
+                        conn_id,
+                        format!("Buffer too small: need {} bytes, got {}", needed, buf_len),
+                    );
+                } else {
+                    set_error(
+                        &mut state,
+                        format!("Buffer too small: need {} bytes, got {}", needed, buf_len),
+                    );
+                }
+                -2
+            }
+            Ok(StreamCopyResult::End) => {
                 // Safety: Pointers must be valid for writes (verified by null checks earlier)
                 unsafe {
                     *out_written = 0;
@@ -5008,15 +4928,12 @@ pub extern "C" fn odbc_stream_cancel(stream_id: c_uint) -> c_int {
             return -1;
         };
 
-        match state.streams.get(&stream_id) {
-            Some(stream) => {
-                stream.cancel();
-                0
-            }
-            None => {
-                set_error(&mut state, format!("Invalid stream ID: {}", stream_id));
-                1
-            }
+        if let Some(stream) = state.streams.get(&stream_id) {
+            stream.cancel();
+            0
+        } else {
+            set_error(&mut state, format!("Invalid stream ID: {}", stream_id));
+            1
         }
     })
 }
@@ -5033,7 +4950,6 @@ pub extern "C" fn odbc_stream_close(stream_id: c_uint) -> c_int {
 
         if state.streams.remove(&stream_id).is_some() {
             state.stream_connections.remove(&stream_id);
-            state.pending_stream_chunks.remove(&stream_id);
             0
         } else {
             set_error(&mut state, format!("Invalid stream ID: {}", stream_id));

--- a/native/odbc_engine/src/ffi/mod.rs
+++ b/native/odbc_engine/src/ffi/mod.rs
@@ -368,6 +368,7 @@ fn take_runnable_connection(state: &mut GlobalState, conn_id: u32) -> Result<Run
     }
 
     if let Some((pool_id, pooled)) = state.pooled_connections.remove(&conn_id) {
+        *state.pooled_busy_counts.entry(pool_id).or_insert(0) += 1;
         return Ok(RunnableConnection::Pooled { pool_id, pooled });
     }
 
@@ -377,6 +378,94 @@ fn take_runnable_connection(state: &mut GlobalState, conn_id: u32) -> Result<Run
 fn restore_pooled_connection(state: &mut GlobalState, conn_id: u32, target: RunnableConnection) {
     if let RunnableConnection::Pooled { pool_id, pooled } = target {
         state.pooled_connections.insert(conn_id, (pool_id, pooled));
+        if let Some(count) = state.pooled_busy_counts.get_mut(&pool_id) {
+            *count = count.saturating_sub(1);
+            if *count == 0 {
+                state.pooled_busy_counts.remove(&pool_id);
+            }
+        }
+    }
+}
+
+fn run_buffered_connection_call<F>(
+    conn_id: u32,
+    out_buffer: *mut u8,
+    buffer_len: c_uint,
+    out_written: *mut c_uint,
+    run: F,
+) -> c_int
+where
+    F: FnOnce(&odbc_api::Connection<'static>) -> Result<Vec<u8>>,
+{
+    let Some(mut state) = try_lock_global_state() else {
+        return -1;
+    };
+    let metrics = Arc::clone(&state.metrics);
+    let start = Instant::now();
+    let mut target = match take_runnable_connection(&mut state, conn_id) {
+        Ok(target) => target,
+        Err(e) => {
+            set_connection_structured_error(&mut state, conn_id, e.to_structured());
+            return -1;
+        }
+    };
+    drop(state);
+
+    let result = match &mut target {
+        RunnableConnection::Regular(conn_arc) => {
+            let conn_guard = match conn_arc.lock() {
+                Ok(g) => g,
+                Err(_) => {
+                    let Some(mut state) = try_lock_global_state() else {
+                        return -1;
+                    };
+                    set_connection_error(
+                        &mut state,
+                        conn_id,
+                        "Failed to lock connection".to_string(),
+                    );
+                    return -1;
+                }
+            };
+            run(conn_guard.connection())
+        }
+        RunnableConnection::Pooled { pooled, .. } => run(pooled.get_connection()),
+    };
+
+    let Some(mut state) = try_lock_global_state() else {
+        return -1;
+    };
+    restore_pooled_connection(&mut state, conn_id, target);
+
+    match result {
+        Ok(data) => {
+            metrics.record_query(start.elapsed());
+            if data.len() > buffer_len as usize {
+                metrics.record_error();
+                set_connection_error(
+                    &mut state,
+                    conn_id,
+                    format!(
+                        "Buffer too small: need {} bytes, got {}",
+                        data.len(),
+                        buffer_len
+                    ),
+                );
+                set_out_written_zero(out_written);
+                return -2;
+            }
+            unsafe {
+                std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
+                *out_written = data.len() as c_uint;
+            }
+            0
+        }
+        Err(e) => {
+            metrics.record_error();
+            set_connection_structured_error(&mut state, conn_id, e.to_structured());
+            set_out_written_zero(out_written);
+            -1
+        }
     }
 }
 
@@ -401,6 +490,7 @@ struct GlobalState {
     pending_result_buffers: HashMap<PendingResultKey, PendingResultBuffer>,
     pools: HashMap<u32, Arc<ConnectionPool>>,
     pooled_connections: HashMap<u32, (u32, PooledConnectionWrapper)>, // pooled_conn_id -> (pool_id, wrapper)
+    pooled_busy_counts: HashMap<u32, usize>, // pool_id -> connections temporarily removed for active FFI calls
     pooled_free_ids: HashMap<u32, Vec<u32>>, // pool_id -> reusable pooled connection IDs
     next_stream_id: u32,
     next_pool_id: u32,
@@ -578,6 +668,7 @@ fn get_global_state() -> &'static Arc<Mutex<GlobalState>> {
             pending_result_buffers: HashMap::new(),
             pools: HashMap::new(),
             pooled_connections: HashMap::new(),
+            pooled_busy_counts: HashMap::new(),
             pooled_free_ids: HashMap::new(),
             next_stream_id: 1,
             next_pool_id: 1,
@@ -960,8 +1051,14 @@ pub extern "C" fn odbc_connect(conn_str: *const c_char) -> c_uint {
             };
             env_guard.get_handles()
         };
+        drop(state);
 
-        match crate::engine::OdbcConnection::connect(handles, conn_str_rust) {
+        let result = crate::engine::OdbcConnection::connect(handles, conn_str_rust);
+
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
+        };
+        match result {
             Ok(conn) => {
                 let conn_id = conn.get_connection_id();
                 state.connections.insert(conn_id, conn);
@@ -1023,12 +1120,18 @@ pub extern "C" fn odbc_connect_with_timeout(conn_str: *const c_char, timeout_ms:
             };
             env_guard.get_handles()
         };
+        drop(state);
 
-        match crate::engine::OdbcConnection::connect_with_timeout(
+        let result = crate::engine::OdbcConnection::connect_with_timeout(
             handles,
             conn_str_rust,
             timeout_secs,
-        ) {
+        );
+
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
+        };
+        match result {
             Ok(conn) => {
                 let conn_id = conn.get_connection_id();
                 state.connections.insert(conn_id, conn);
@@ -1070,9 +1173,10 @@ pub extern "C" fn odbc_disconnect(conn_id: c_uint) -> c_int {
                 .filter(|(_, t)| t.conn_id() == conn_id)
                 .map(|(id, _)| *id)
                 .collect();
+            let mut transactions = Vec::with_capacity(txns_to_rollback.len());
             for txn_id in txns_to_rollback {
                 if let Some(txn) = state.transactions.remove(&txn_id) {
-                    let _ = txn.rollback();
+                    transactions.push(txn);
                 }
             }
             let stmts_to_drop: Vec<u32> = state
@@ -1111,7 +1215,17 @@ pub extern "C" fn odbc_disconnect(conn_id: c_uint) -> c_int {
                 } => *key_conn != conn_id,
                 PendingResultKey::Execute { stmt_id, .. } => !stmts_to_drop.contains(stmt_id),
             });
-            match conn.disconnect() {
+            drop(state);
+
+            for txn in transactions {
+                let _ = txn.rollback();
+            }
+            let disconnect_result = conn.disconnect();
+
+            let Some(mut state) = try_lock_global_state() else {
+                return -1;
+            };
+            match disconnect_result {
                 Ok(_) => {
                     // Remove connection error when disconnecting
                     state.connection_errors.remove(&conn_id);
@@ -1381,12 +1495,21 @@ where
     let Some(mut state) = try_lock_global_state() else {
         return -1;
     };
-    let Some(txn) = state.transactions.get(&txn_id) else {
+    let Some(txn) = state.transactions.remove(&txn_id) else {
         set_error(&mut state, format!("Invalid transaction ID: {}", txn_id));
         return 1;
     };
     let conn_id = txn.conn_id();
-    match action(txn, name_str) {
+    drop(state);
+
+    let result = action(&txn, name_str);
+
+    let Some(mut state) = try_lock_global_state() else {
+        return -1;
+    };
+    state.transactions.insert(txn_id, txn);
+
+    match result {
         Ok(()) => 0,
         Err(e) => {
             set_connection_error(&mut state, conn_id, format!("Savepoint {op} failed: {}", e));
@@ -1561,8 +1684,14 @@ pub extern "C" fn odbc_xa_start(
         let Some(handles) = state.connections.get(&conn_id).map(|c| c.get_handles()) else {
             return 0;
         };
+        drop(state);
 
-        let xa = match XaTransaction::start(handles, conn_id, xid) {
+        let xa_result = XaTransaction::start(handles, conn_id, xid);
+
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
+        };
+        let xa = match xa_result {
             Ok(x) => x,
             Err(e) => {
                 set_connection_error(&mut state, conn_id, format!("odbc_xa_start: {}", e));
@@ -1595,7 +1724,14 @@ pub extern "C" fn odbc_xa_end(xa_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid XA ID (Active): {}", xa_id));
             return 1;
         };
-        match xa.end() {
+        drop(state);
+
+        let result = xa.end();
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        match result {
             Ok(preparing) => {
                 state.xa_preparing.insert(xa_id, preparing);
                 0
@@ -1623,7 +1759,14 @@ pub extern "C" fn odbc_xa_prepare(xa_id: c_uint) -> c_int {
             );
             return 1;
         };
-        match preparing.prepare() {
+        drop(state);
+
+        let result = preparing.prepare();
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        match result {
             Ok(prepared) => {
                 state.xa_prepared.insert(xa_id, prepared);
                 0
@@ -1647,10 +1790,14 @@ pub extern "C" fn odbc_xa_commit_prepared(xa_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid XA ID (Prepared): {}", xa_id));
             return 1;
         };
+        drop(state);
+
         match prepared.commit() {
             Ok(()) => 0,
             Err(e) => {
-                set_error(&mut state, format!("xa_commit_prepared failed: {}", e));
+                if let Some(mut state) = try_lock_global_state() {
+                    set_error(&mut state, format!("xa_commit_prepared failed: {}", e));
+                }
                 1
             }
         }
@@ -1668,10 +1815,14 @@ pub extern "C" fn odbc_xa_rollback_prepared(xa_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid XA ID (Prepared): {}", xa_id));
             return 1;
         };
+        drop(state);
+
         match prepared.rollback() {
             Ok(()) => 0,
             Err(e) => {
-                set_error(&mut state, format!("xa_rollback_prepared failed: {}", e));
+                if let Some(mut state) = try_lock_global_state() {
+                    set_error(&mut state, format!("xa_rollback_prepared failed: {}", e));
+                }
                 1
             }
         }
@@ -1691,10 +1842,14 @@ pub extern "C" fn odbc_xa_commit_one_phase(xa_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid XA ID (Active): {}", xa_id));
             return 1;
         };
+        drop(state);
+
         match xa.commit_one_phase() {
             Ok(()) => 0,
             Err(e) => {
-                set_error(&mut state, format!("xa_commit_one_phase failed: {}", e));
+                if let Some(mut state) = try_lock_global_state() {
+                    set_error(&mut state, format!("xa_commit_one_phase failed: {}", e));
+                }
                 1
             }
         }
@@ -1713,10 +1868,14 @@ pub extern "C" fn odbc_xa_rollback_active(xa_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid XA ID (Active): {}", xa_id));
             return 1;
         };
+        drop(state);
+
         match xa.rollback() {
             Ok(()) => 0,
             Err(e) => {
-                set_error(&mut state, format!("xa_rollback_active failed: {}", e));
+                if let Some(mut state) = try_lock_global_state() {
+                    set_error(&mut state, format!("xa_rollback_active failed: {}", e));
+                }
                 1
             }
         }
@@ -1897,7 +2056,14 @@ pub extern "C" fn odbc_xa_resume_prepared(
             );
             return 0;
         };
-        let prepared = match resume_prepared(handles, conn_id, xid) {
+        drop(state);
+
+        let prepared_result = resume_prepared(handles, conn_id, xid);
+
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
+        };
+        let prepared = match prepared_result {
             Ok(p) => p,
             Err(e) => {
                 set_connection_error(
@@ -2508,31 +2674,51 @@ pub extern "C" fn odbc_get_connection_dbms_info(
             set_out_written_zero(out_written);
             return -1;
         }
-        let Some(state) = try_lock_global_state() else {
+        let Some(mut state) = try_lock_global_state() else {
             set_out_written_zero(out_written);
             return -1;
         };
-
-        // Try direct connections first, then pooled connections.
-        let info_result = if let Some(conn) = state.connections.get(&conn_id) {
-            let handles = conn.get_handles();
-            DbmsInfo::detect_for_conn_id(&handles, conn_id)
-        } else if let Some((_pool_id, pooled)) = state.pooled_connections.get(&conn_id) {
-            DbmsInfo::detect(pooled.get_connection())
-        } else {
-            let mut state_mut = state;
-            set_error(&mut state_mut, format!("Invalid connection ID: {conn_id}"));
-            set_out_written_zero(out_written);
-            return -1;
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                set_out_written_zero(out_written);
+                return -1;
+            }
         };
         drop(state);
+
+        let info_result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        if let Some(mut state) = try_lock_global_state() {
+                            set_connection_error(
+                                &mut state,
+                                conn_id,
+                                "Failed to lock connection".to_string(),
+                            );
+                        }
+                        set_out_written_zero(out_written);
+                        return -1;
+                    }
+                };
+                DbmsInfo::detect(conn_guard.connection())
+            }
+            RunnableConnection::Pooled { pooled, .. } => DbmsInfo::detect(pooled.get_connection()),
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
+            set_out_written_zero(out_written);
+            return -1;
+        };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         let info = match info_result {
             Ok(i) => i,
             Err(e) => {
-                if let Some(mut s) = try_lock_global_state() {
-                    set_connection_error(&mut s, conn_id, e.to_string());
-                }
+                set_connection_error(&mut state, conn_id, e.to_string());
                 set_out_written_zero(out_written);
                 return -1;
             }
@@ -2860,86 +3046,46 @@ pub extern "C" fn odbc_exec_query(
             return code;
         }
 
-        // Resolve `conn_id` to a runnable query. We accept both:
-        //   1. plain connection IDs created by `odbc_connect`
-        //      (`state.connections`), and
-        //   2. pooled IDs handed out by `odbc_pool_get_connection`
-        //      (`state.pooled_connections`).
-        // Until v3.1.1 only path (1) was implemented here, so any caller
-        // using `odbc_pool_get_connection` + `odbc_exec_query` got
-        // "Invalid connection ID" -- this regressed the
-        // `test_ffi_pool_release_raii_rollback_autocommit` E2E test.
-        let result = if let Some(handles) = state.connections.get(&conn_id).map(|c| c.get_handles())
-        {
-            let Ok(handles_guard) = handles.lock() else {
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    set_out_written_zero(out_written);
-                    return -1;
-                };
-                set_error(&mut state, "Failed to lock handles mutex".to_string());
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
                 set_out_written_zero(out_written);
                 return -1;
-            };
-            let conn_arc = match handles_guard.get_connection(conn_id) {
-                Ok(c) => c,
-                Err(e) => {
-                    drop(handles_guard);
-                    drop(state);
-                    let Some(mut state) = try_lock_global_state() else {
-                        set_out_written_zero(out_written);
-                        return -1;
-                    };
-                    set_error(&mut state, format!("Failed to get connection: {}", e));
-                    set_out_written_zero(out_written);
-                    return -1;
-                }
-            };
-            drop(handles_guard);
-            drop(state);
+            }
+        };
+        drop(state);
 
-            let mut conn_guard = match conn_arc.lock() {
-                Ok(g) => g,
-                Err(_) => {
-                    let Some(mut state) = try_lock_global_state() else {
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let mut conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            set_out_written_zero(out_written);
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
                         set_out_written_zero(out_written);
                         return -1;
-                    };
-                    set_error(&mut state, "Failed to lock connection".to_string());
-                    set_out_written_zero(out_written);
-                    return -1;
-                }
-            };
-            execute_query_with_cached_connection(&mut conn_guard, sql_str)
-        } else if let Some((pool_id, pooled)) = state.pooled_connections.remove(&conn_id) {
-            drop(state);
-            let result = execute_query_with_connection(pooled.get_connection(), sql_str);
-            let Some(mut state) = try_lock_global_state() else {
-                set_out_written_zero(out_written);
-                return -1;
-            };
-            state.pooled_connections.insert(conn_id, (pool_id, pooled));
-            drop(state);
-            result
-        } else {
-            drop(state);
-            let Some(mut state) = try_lock_global_state() else {
-                set_out_written_zero(out_written);
-                return -1;
-            };
-            set_connection_error(
-                &mut state,
-                conn_id,
-                format!("Invalid connection ID: {}", conn_id),
-            );
-            set_out_written_zero(out_written);
-            return -1;
+                    }
+                };
+                execute_query_with_cached_connection(&mut conn_guard, sql_str)
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                execute_query_with_connection(pooled.get_connection(), sql_str)
+            }
         };
 
         let Some(mut state) = try_lock_global_state() else {
             set_out_written_zero(out_written);
             return -1;
         };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         match result {
             Ok(data) => {
@@ -2970,11 +3116,6 @@ pub extern "C" fn odbc_exec_query(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    set_out_written_zero(out_written);
-                    return -1;
-                };
                 let structured = e.to_structured();
                 set_connection_structured_error(&mut state, conn_id, structured);
                 let error_message = state
@@ -3592,101 +3733,9 @@ pub extern "C" fn odbc_catalog_tables(
         let cat_ref = cat_opt.as_deref();
         let sch_ref = sch_opt.as_deref();
 
-        let Some(state) = try_lock_global_state() else {
-            return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
-        let metrics = Arc::clone(&state.metrics);
-        let start = Instant::now();
-
-        match list_tables(conn_guard.connection(), cat_ref, sch_ref) {
-            Ok(data) => {
-                metrics.record_query(start.elapsed());
-                if data.len() > buffer_len as usize {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            data.len(),
-                            buffer_len
-                        ),
-                    );
-                    return -2;
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
-                    *out_written = data.len() as c_uint;
-                }
-                0
-            }
-            Err(e) => {
-                metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
-                -1
-            }
-        }
+        run_buffered_connection_call(conn_id, out_buffer, buffer_len, out_written, |conn| {
+            list_tables(conn, cat_ref, sch_ref)
+        })
     })
 }
 
@@ -3712,35 +3761,15 @@ pub extern "C" fn odbc_catalog_columns(
             Err(_) => return -1,
         };
 
-        let Some(state) = try_lock_global_state() else {
+        let Some(mut state) = try_lock_global_state() else {
             return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
         };
 
         let cache_key = format!("{}:{}", conn_id, table_str);
         if let Some(cached_data) = state.metadata_cache.get_payload(&cache_key) {
             if cached_data.len() > buffer_len as usize {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
                 set_connection_error(
-                    &mut s,
+                    &mut state,
                     conn_id,
                     format!(
                         "Buffer too small: need {} bytes, got {}",
@@ -3748,6 +3777,7 @@ pub extern "C" fn odbc_catalog_columns(
                         buffer_len
                     ),
                 );
+                set_out_written_zero(out_written);
                 return -2;
             }
             unsafe {
@@ -3757,57 +3787,54 @@ pub extern "C" fn odbc_catalog_columns(
             return 0;
         }
 
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
         let metrics = Arc::clone(&state.metrics);
         let start = Instant::now();
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                set_out_written_zero(out_written);
+                return -1;
+            }
+        };
+        drop(state);
 
-        match list_columns(conn_guard.connection(), table_str) {
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        return -1;
+                    }
+                };
+                list_columns(conn_guard.connection(), table_str)
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                list_columns(pooled.get_connection(), table_str)
+            }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        restore_pooled_connection(&mut state, conn_id, target);
+
+        match result {
             Ok(data) => {
                 metrics.record_query(start.elapsed());
                 state.metadata_cache.cache_payload(&cache_key, &data);
                 if data.len() > buffer_len as usize {
                     metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
                     set_connection_error(
-                        &mut s,
+                        &mut state,
                         conn_id,
                         format!(
                             "Buffer too small: need {} bytes, got {}",
@@ -3815,6 +3842,7 @@ pub extern "C" fn odbc_catalog_columns(
                             buffer_len
                         ),
                     );
+                    set_out_written_zero(out_written);
                     return -2;
                 }
                 unsafe {
@@ -3825,11 +3853,8 @@ pub extern "C" fn odbc_catalog_columns(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                set_out_written_zero(out_written);
                 -1
             }
         }
@@ -3850,101 +3875,7 @@ pub extern "C" fn odbc_catalog_type_info(
             return -1;
         }
 
-        let Some(state) = try_lock_global_state() else {
-            return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
-        let metrics = Arc::clone(&state.metrics);
-        let start = Instant::now();
-
-        match get_type_info(conn_guard.connection()) {
-            Ok(data) => {
-                metrics.record_query(start.elapsed());
-                if data.len() > buffer_len as usize {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            data.len(),
-                            buffer_len
-                        ),
-                    );
-                    return -2;
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
-                    *out_written = data.len() as c_uint;
-                }
-                0
-            }
-            Err(e) => {
-                metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
-                -1
-            }
-        }
+        run_buffered_connection_call(conn_id, out_buffer, buffer_len, out_written, get_type_info)
     })
 }
 
@@ -3965,31 +3896,10 @@ pub extern "C" fn odbc_catalog_primary_keys(
             return -1;
         }
 
-        let Some(state) = try_lock_global_state() else {
-            return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
         let c_str = unsafe { CStr::from_ptr(table) };
         let table_str = match c_str.to_str() {
             Ok(s) => s,
             Err(_) => {
-                drop(state);
                 let Some(mut s) = try_lock_global_state() else {
                     return -1;
                 };
@@ -3998,81 +3908,9 @@ pub extern "C" fn odbc_catalog_primary_keys(
             }
         };
 
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
-        let metrics = Arc::clone(&state.metrics);
-        let start = Instant::now();
-
-        match list_primary_keys(conn_guard.connection(), table_str) {
-            Ok(data) => {
-                metrics.record_query(start.elapsed());
-                if data.len() > buffer_len as usize {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            data.len(),
-                            buffer_len
-                        ),
-                    );
-                    return -2;
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
-                    *out_written = data.len() as c_uint;
-                }
-                0
-            }
-            Err(e) => {
-                metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
-                -1
-            }
-        }
+        run_buffered_connection_call(conn_id, out_buffer, buffer_len, out_written, |conn| {
+            list_primary_keys(conn, table_str)
+        })
     })
 }
 
@@ -4093,31 +3931,10 @@ pub extern "C" fn odbc_catalog_foreign_keys(
             return -1;
         }
 
-        let Some(state) = try_lock_global_state() else {
-            return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
         let c_str = unsafe { CStr::from_ptr(table) };
         let table_str = match c_str.to_str() {
             Ok(s) => s,
             Err(_) => {
-                drop(state);
                 let Some(mut s) = try_lock_global_state() else {
                     return -1;
                 };
@@ -4126,81 +3943,9 @@ pub extern "C" fn odbc_catalog_foreign_keys(
             }
         };
 
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
-        let metrics = Arc::clone(&state.metrics);
-        let start = Instant::now();
-
-        match list_foreign_keys(conn_guard.connection(), table_str) {
-            Ok(data) => {
-                metrics.record_query(start.elapsed());
-                if data.len() > buffer_len as usize {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            data.len(),
-                            buffer_len
-                        ),
-                    );
-                    return -2;
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
-                    *out_written = data.len() as c_uint;
-                }
-                0
-            }
-            Err(e) => {
-                metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
-                -1
-            }
-        }
+        run_buffered_connection_call(conn_id, out_buffer, buffer_len, out_written, |conn| {
+            list_foreign_keys(conn, table_str)
+        })
     })
 }
 
@@ -4221,31 +3966,10 @@ pub extern "C" fn odbc_catalog_indexes(
             return -1;
         }
 
-        let Some(state) = try_lock_global_state() else {
-            return -1;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
         let c_str = unsafe { CStr::from_ptr(table) };
         let table_str = match c_str.to_str() {
             Ok(s) => s,
             Err(_) => {
-                drop(state);
                 let Some(mut s) = try_lock_global_state() else {
                     return -1;
                 };
@@ -4254,81 +3978,9 @@ pub extern "C" fn odbc_catalog_indexes(
             }
         };
 
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
-        let metrics = Arc::clone(&state.metrics);
-        let start = Instant::now();
-
-        match list_indexes(conn_guard.connection(), table_str) {
-            Ok(data) => {
-                metrics.record_query(start.elapsed());
-                if data.len() > buffer_len as usize {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!(
-                            "Buffer too small: need {} bytes, got {}",
-                            data.len(),
-                            buffer_len
-                        ),
-                    );
-                    return -2;
-                }
-                unsafe {
-                    std::ptr::copy_nonoverlapping(data.as_ptr(), out_buffer, data.len());
-                    *out_written = data.len() as c_uint;
-                }
-                0
-            }
-            Err(e) => {
-                metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
-                -1
-            }
-        }
+        run_buffered_connection_call(conn_id, out_buffer, buffer_len, out_written, |conn| {
+            list_indexes(conn, table_str)
+        })
     })
 }
 
@@ -5599,14 +5251,20 @@ pub extern "C" fn odbc_pool_release_connection(connection_id: c_uint) -> c_int {
         };
 
         if let Some((pool_id, mut pooled)) = state.pooled_connections.remove(&connection_id) {
+            state
+                .statements
+                .retain(|_, stmt| stmt.conn_id() != connection_id);
+            drop(state);
+
             // RAII: rollback any active transaction and restore autocommit before returning to pool
             let conn = pooled.get_connection_mut();
             let _ = conn.rollback();
             let _ = conn.set_autocommit(true);
+            drop(pooled);
 
-            state
-                .statements
-                .retain(|_, stmt| stmt.conn_id() != connection_id);
+            let Some(mut state) = try_lock_global_state() else {
+                return -1;
+            };
             state
                 .pooled_free_ids
                 .entry(pool_id)
@@ -5776,11 +5434,10 @@ pub extern "C" fn odbc_pool_set_size(pool_id: c_uint, new_max_size: c_uint) -> c
             return -1;
         }
 
-        let Some(mut state) = try_lock_global_state() else {
-            return -1;
-        };
-
         let conn_str = {
+            let Some(mut state) = try_lock_global_state() else {
+                return -1;
+            };
             let pool = match state.pools.get(&pool_id) {
                 Some(p) => p,
                 None => {
@@ -5799,21 +5456,48 @@ pub extern "C" fn odbc_pool_set_size(pool_id: c_uint, new_max_size: c_uint) -> c
                 );
                 return -1;
             }
+            if state.pooled_busy_counts.get(&pool_id).copied().unwrap_or(0) > 0 {
+                set_error(
+                    &mut state,
+                    "Cannot resize pool while connections are executing".to_string(),
+                );
+                return -1;
+            }
             pool.connection_string().to_string()
         };
 
-        state.pools.remove(&pool_id);
-
-        match ConnectionPool::new(&conn_str, new_max_size) {
-            Ok(pool) => {
-                state.pools.insert(pool_id, Arc::new(pool));
-                0
-            }
+        let pool = match ConnectionPool::new(&conn_str, new_max_size) {
+            Ok(pool) => pool,
             Err(e) => {
+                let Some(mut state) = try_lock_global_state() else {
+                    return -1;
+                };
                 set_error(&mut state, format!("odbc_pool_set_size failed: {}", e));
-                -1
+                return -1;
             }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        if state
+            .pooled_connections
+            .values()
+            .any(|(pid, _)| *pid == pool_id)
+            || state.pooled_busy_counts.get(&pool_id).copied().unwrap_or(0) > 0
+        {
+            set_error(
+                &mut state,
+                "Cannot resize pool while connections are checked out or executing".to_string(),
+            );
+            return -1;
         }
+        if !state.pools.contains_key(&pool_id) {
+            set_error(&mut state, format!("Invalid pool ID: {}", pool_id));
+            return -1;
+        }
+        state.pools.insert(pool_id, Arc::new(pool));
+        0
     })
 }
 
@@ -5832,31 +5516,45 @@ pub extern "C" fn odbc_pool_close(pool_id: c_uint) -> c_int {
             set_error(&mut state, format!("Invalid pool ID: {}", pool_id));
             return 1;
         }
+        if state.pooled_busy_counts.get(&pool_id).copied().unwrap_or(0) > 0 {
+            set_error(
+                &mut state,
+                "Cannot close pool while connections are executing".to_string(),
+            );
+            return 1;
+        }
 
-        // C4 fix: drain checked-out connections **before** removing the pool from
-        // the map. r2d2 returns a `PooledConnection` that releases back to the
-        // pool on Drop; if we removed the pool first and then dropped the last
-        // wrapper, r2d2 could deadlock waiting on internals that we just
-        // dismantled. Order matters: drop conns → drop free-id buckets → drop pool.
+        // Prevent new checkouts while keeping the pool Arc alive locally until
+        // checked-out wrappers are rolled back, restored and dropped.
+        // r2d2 returns a `PooledConnection` that releases back to the pool on
+        // Drop; holding this Arc preserves pool internals until wrappers drop.
+        let pool = state
+            .pools
+            .remove(&pool_id)
+            .expect("pool existence checked above");
         let conn_ids: Vec<u32> = state
             .pooled_connections
             .iter()
             .filter(|(_, (pid, _))| *pid == pool_id)
             .map(|(cid, _)| *cid)
             .collect();
+        let mut checked_out = Vec::with_capacity(conn_ids.len());
         for cid in conn_ids {
             state.statements.retain(|_, stmt| stmt.conn_id() != cid);
-            if let Some((_, mut pooled)) = state.pooled_connections.remove(&cid) {
-                let conn = pooled.get_connection_mut();
-                let _ = conn.rollback();
-                let _ = conn.set_autocommit(true);
-                // `pooled` is dropped here, releasing the connection back to the pool.
+            if let Some((_, pooled)) = state.pooled_connections.remove(&cid) {
+                checked_out.push(pooled);
             }
         }
         state.pooled_free_ids.remove(&pool_id);
+        drop(state);
 
-        // Now safe to remove the pool itself; no live checkouts remain.
-        state.pools.remove(&pool_id);
+        for mut pooled in checked_out {
+            let conn = pooled.get_connection_mut();
+            let _ = conn.rollback();
+            let _ = conn.set_autocommit(true);
+            // `pooled` is dropped here, releasing the connection back to the pool.
+        }
+        drop(pool);
         0
     })
 }

--- a/native/odbc_engine/src/ffi/mod.rs
+++ b/native/odbc_engine/src/ffi/mod.rs
@@ -22,15 +22,17 @@ use crate::engine::{
 };
 use crate::error::StructuredError;
 use crate::error::{OdbcError, Result};
-use crate::handles::SharedHandleManager;
+use crate::handles::{SharedConnection, SharedHandleManager};
 use crate::observability::Metrics;
 use crate::plugins::PluginRegistry;
 use crate::pool::{ConnectionPool, PooledConnectionWrapper};
 use crate::protocol::bound_param::ParamDirection;
 use crate::protocol::{
-    bound_param::ParamList, bulk_insert::is_null, deserialize_param_buffer,
-    parse_bulk_insert_payload, BulkColumnData, BulkInsertPayload, ParamValue,
+    bound_param::ParamList, deserialize_param_buffer, parse_bulk_insert_payload, BulkInsertPayload,
+    ParamValue,
 };
+#[cfg(feature = "sqlserver-bcp")]
+use crate::protocol::{bulk_insert::is_null, BulkColumnData};
 use crate::security::AuditLogger;
 use log::LevelFilter;
 use rayon::prelude::*;
@@ -345,6 +347,37 @@ fn run_async_query(handles: SharedHandleManager, conn_id: u32, sql: &str) -> Res
         .lock()
         .map_err(|_| OdbcError::InternalError("Failed to lock connection".to_string()))?;
     execute_query_with_cached_connection(&mut conn_guard, sql)
+}
+
+enum RunnableConnection {
+    Regular(SharedConnection),
+    Pooled {
+        pool_id: u32,
+        pooled: PooledConnectionWrapper,
+    },
+}
+
+fn take_runnable_connection(state: &mut GlobalState, conn_id: u32) -> Result<RunnableConnection> {
+    if let Some(conn) = state.connections.get(&conn_id) {
+        let handles = conn.get_handles();
+        let handles_guard = handles
+            .lock()
+            .map_err(|_| OdbcError::InternalError("Failed to lock handles mutex".to_string()))?;
+        let conn_arc = handles_guard.get_connection(conn_id)?;
+        return Ok(RunnableConnection::Regular(conn_arc));
+    }
+
+    if let Some((pool_id, pooled)) = state.pooled_connections.remove(&conn_id) {
+        return Ok(RunnableConnection::Pooled { pool_id, pooled });
+    }
+
+    Err(OdbcError::InvalidHandle(conn_id))
+}
+
+fn restore_pooled_connection(state: &mut GlobalState, conn_id: u32, target: RunnableConnection) {
+    if let RunnableConnection::Pooled { pool_id, pooled } = target {
+        state.pooled_connections.insert(conn_id, (pool_id, pooled));
+    }
 }
 
 struct GlobalState {
@@ -3134,58 +3167,6 @@ pub extern "C" fn odbc_exec_query_params(
             return -1;
         };
 
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(
-                    &mut s,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, format!("Failed to get connection: {}", e));
-                return -1;
-            }
-        };
-        drop(handles_guard);
-
-        let mut conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
-
         let metrics = Arc::clone(&state.metrics);
         let start = Instant::now();
         let params_hash = if params_buffer.is_null() || params_len == 0 {
@@ -3210,24 +3191,58 @@ pub extern "C" fn odbc_exec_query_params(
             return code;
         }
 
-        let result = if params_buffer.is_null() || params_len == 0 {
-            execute_query_with_cached_connection(&mut conn_guard, sql_str)
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                set_out_written_zero(out_written);
+                return -1;
+            }
+        };
+        drop(state);
+
+        let params_slice = if params_buffer.is_null() || params_len == 0 {
+            &[][..]
         } else {
-            let params_slice =
-                unsafe { std::slice::from_raw_parts(params_buffer, params_len as usize) };
-            match execute_query_with_param_buffer(conn_guard.connection(), sql_str, params_slice) {
-                Ok(d) => Ok(d),
-                Err(e) => {
-                    metrics.record_error();
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
+            unsafe { std::slice::from_raw_parts(params_buffer, params_len as usize) }
+        };
+
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let mut conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        set_out_written_zero(out_written);
                         return -1;
-                    };
-                    set_connection_error(&mut s, conn_id, e.to_string());
-                    return -1;
+                    }
+                };
+                if params_slice.is_empty() {
+                    execute_query_with_cached_connection(&mut conn_guard, sql_str)
+                } else {
+                    execute_query_with_param_buffer(conn_guard.connection(), sql_str, params_slice)
+                }
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                if params_slice.is_empty() {
+                    execute_query_with_connection(pooled.get_connection(), sql_str)
+                } else {
+                    execute_query_with_param_buffer(pooled.get_connection(), sql_str, params_slice)
                 }
             }
         };
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         match result {
             Ok(data) => {
@@ -3244,6 +3259,7 @@ pub extern "C" fn odbc_exec_query_params(
                             data_len, buffer_len
                         ),
                     );
+                    set_out_written_zero(out_written);
                     return -2;
                 }
 
@@ -3258,12 +3274,9 @@ pub extern "C" fn odbc_exec_query_params(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
                 let structured = e.to_structured();
-                set_connection_structured_error(&mut s, conn_id, structured);
+                set_connection_structured_error(&mut state, conn_id, structured);
+                set_out_written_zero(out_written);
                 -1
             }
         }
@@ -3318,65 +3331,42 @@ pub extern "C" fn odbc_exec_query_multi(
             return code;
         }
 
-        // Resolve `conn_id` to a runnable query (M2 fix). Accepts plain conn IDs
-        // and pooled IDs (>= 1_000_000) returned by `odbc_pool_get_connection`.
-        let result = if state.connections.contains_key(&conn_id) {
-            let handles = state
-                .connections
-                .get(&conn_id)
-                .expect("conn_id present, just checked")
-                .get_handles();
-            let Ok(handles_guard) = handles.lock() else {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                return -1;
+            }
+        };
+        drop(state);
+
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        return -1;
+                    }
                 };
-                set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-                return -1;
-            };
-            let conn_arc = match handles_guard.get_connection(conn_id) {
-                Ok(c) => c,
-                Err(e) => {
-                    drop(handles_guard);
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!("Failed to get connection: {}", e),
-                    );
-                    return -1;
-                }
-            };
-            drop(handles_guard);
-            let conn_guard = match conn_arc.lock() {
-                Ok(g) => g,
-                Err(_) => {
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                    return -1;
-                }
-            };
-            execute_multi_result(conn_guard.connection(), sql_str)
-        } else if let Some((_pool_id, pooled)) = state.pooled_connections.get(&conn_id) {
-            execute_multi_result(pooled.get_connection(), sql_str)
-        } else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(
-                &mut s,
-                conn_id,
-                format!("Invalid connection ID: {}", conn_id),
-            );
+                execute_multi_result(conn_guard.connection(), sql_str)
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                execute_multi_result(pooled.get_connection(), sql_str)
+            }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
             return -1;
         };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         match result {
             Ok(data) => {
@@ -3407,12 +3397,8 @@ pub extern "C" fn odbc_exec_query_multi(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
                 let structured = e.to_structured();
-                set_connection_structured_error(&mut s, conn_id, structured);
+                set_connection_structured_error(&mut state, conn_id, structured);
                 -1
             }
         }
@@ -3508,63 +3494,44 @@ pub extern "C" fn odbc_exec_query_multi_params(
             return code;
         }
 
-        let result = if state.connections.contains_key(&conn_id) {
-            let handles = state
-                .connections
-                .get(&conn_id)
-                .expect("conn_id present, just checked")
-                .get_handles();
-            let Ok(handles_guard) = handles.lock() else {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                set_out_written_zero(out_written);
+                return -1;
+            }
+        };
+        drop(state);
+
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        set_out_written_zero(out_written);
+                        return -1;
+                    }
                 };
-                set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-                return -1;
-            };
-            let conn_arc = match handles_guard.get_connection(conn_id) {
-                Ok(c) => c,
-                Err(e) => {
-                    drop(handles_guard);
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!("Failed to get connection: {}", e),
-                    );
-                    return -1;
-                }
-            };
-            drop(handles_guard);
-            let conn_guard = match conn_arc.lock() {
-                Ok(g) => g,
-                Err(_) => {
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                    return -1;
-                }
-            };
-            execute_multi_result_with_params(conn_guard.connection(), sql_str, &params)
-        } else if let Some((_pool_id, pooled)) = state.pooled_connections.get(&conn_id) {
-            execute_multi_result_with_params(pooled.get_connection(), sql_str, &params)
-        } else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(
-                &mut s,
-                conn_id,
-                format!("Invalid connection ID: {}", conn_id),
-            );
+                execute_multi_result_with_params(conn_guard.connection(), sql_str, &params)
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                execute_multi_result_with_params(pooled.get_connection(), sql_str, &params)
+            }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
             return -1;
         };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         match result {
             Ok(data) => {
@@ -3593,12 +3560,8 @@ pub extern "C" fn odbc_exec_query_multi_params(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
                 let structured = e.to_structured();
-                set_connection_structured_error(&mut s, conn_id, structured);
+                set_connection_structured_error(&mut state, conn_id, structured);
                 set_out_written_zero(out_written);
                 -1
             }
@@ -4521,74 +4484,54 @@ pub extern "C" fn odbc_execute(
             None
         };
 
-        let result = if let Some(conn) = state.connections.get(&conn_id) {
-            let handles = conn.get_handles();
-            let Some(handles_guard) = handles.lock().ok() else {
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                return -1;
+            }
+        };
+        drop(state);
+
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        return -1;
+                    }
                 };
-                set_connection_error(&mut s, conn_id, "Failed to lock handles mutex".to_string());
-                return -1;
-            };
+                execute_query_with_param_buffer_and_timeout(
+                    conn_guard.connection(),
+                    &sql_str,
+                    params_slice,
+                    timeout_sec,
+                    fetch_size_opt,
+                )
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                execute_query_with_param_buffer_and_timeout(
+                    pooled.get_connection(),
+                    &sql_str,
+                    params_slice,
+                    timeout_sec,
+                    fetch_size_opt,
+                )
+            }
+        };
 
-            let conn_arc = match handles_guard.get_connection(conn_id) {
-                Ok(c) => c,
-                Err(e) => {
-                    drop(handles_guard);
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(
-                        &mut s,
-                        conn_id,
-                        format!("Failed to get connection: {}", e),
-                    );
-                    return -1;
-                }
-            };
-            drop(handles_guard);
-
-            let conn_guard = match conn_arc.lock() {
-                Ok(g) => g,
-                Err(_) => {
-                    drop(state);
-                    let Some(mut s) = try_lock_global_state() else {
-                        return -1;
-                    };
-                    set_connection_error(&mut s, conn_id, "Failed to lock connection".to_string());
-                    return -1;
-                }
-            };
-
-            execute_query_with_param_buffer_and_timeout(
-                conn_guard.connection(),
-                &sql_str,
-                params_slice,
-                timeout_sec,
-                fetch_size_opt,
-            )
-        } else if let Some((_pool_id, pooled)) = state.pooled_connections.get(&conn_id) {
-            execute_query_with_param_buffer_and_timeout(
-                pooled.get_connection(),
-                &sql_str,
-                params_slice,
-                timeout_sec,
-                fetch_size_opt,
-            )
-        } else {
-            drop(state);
-            let Some(mut s) = try_lock_global_state() else {
-                return -1;
-            };
-            set_connection_error(
-                &mut s,
-                conn_id,
-                format!("Connection {} no longer valid", conn_id),
-            );
+        let Some(mut state) = try_lock_global_state() else {
             return -1;
         };
+        restore_pooled_connection(&mut state, conn_id, target);
 
         match result {
             Ok(data) => {
@@ -4616,11 +4559,7 @@ pub extern "C" fn odbc_execute(
             }
             Err(e) => {
                 metrics.record_error();
-                drop(state);
-                let Some(mut s) = try_lock_global_state() else {
-                    return -1;
-                };
-                set_connection_structured_error(&mut s, conn_id, e.to_structured());
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
                 -1
             }
         }
@@ -4732,62 +4671,6 @@ pub extern "C" fn odbc_stream_start(
             Err(_) => return 0,
         };
 
-        let Some(state) = try_lock_global_state() else {
-            return 0;
-        };
-
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    return 0;
-                };
-                set_connection_error(
-                    &mut state,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return 0;
-            }
-        };
-
-        let handles = conn.get_handles();
-        let Some(handles_guard) = handles.lock().ok() else {
-            drop(state);
-            let Some(mut state) = try_lock_global_state() else {
-                return 0;
-            };
-            set_error(&mut state, "Failed to lock handles mutex".to_string());
-            return 0;
-        };
-
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
-            Err(e) => {
-                drop(handles_guard);
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    return 0;
-                };
-                set_error(&mut state, format!("Failed to get connection: {}", e));
-                return 0;
-            }
-        };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    return 0;
-                };
-                set_error(&mut state, "Failed to lock connection".to_string());
-                return 0;
-            }
-        };
-
         let chunk_size = if chunk_size > 0 {
             chunk_size as usize
         } else {
@@ -4798,20 +4681,69 @@ pub extern "C" fn odbc_stream_start(
             .and_then(|s| s.parse::<usize>().ok())
             .filter(|&t| t > 0);
 
-        let executor = StreamingExecutor::new(chunk_size);
-        let stream_state = if let Some(threshold) = spill_threshold_mb {
-            executor.execute_streaming_with_spill(conn_guard.connection(), sql_str, Some(threshold))
-        } else {
-            executor
-                .execute_streaming(conn_guard.connection(), sql_str)
-                .map(crate::engine::StreamState::InMemory)
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
         };
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
+            Err(e) => {
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
+                return 0;
+            }
+        };
+        drop(state);
+
+        let executor = StreamingExecutor::new(chunk_size);
+        let stream_state = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return 0;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        return 0;
+                    }
+                };
+                if let Some(threshold) = spill_threshold_mb {
+                    executor.execute_streaming_with_spill(
+                        conn_guard.connection(),
+                        sql_str,
+                        Some(threshold),
+                    )
+                } else {
+                    executor
+                        .execute_streaming(conn_guard.connection(), sql_str)
+                        .map(crate::engine::StreamState::InMemory)
+                }
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                if let Some(threshold) = spill_threshold_mb {
+                    executor.execute_streaming_with_spill(
+                        pooled.get_connection(),
+                        sql_str,
+                        Some(threshold),
+                    )
+                } else {
+                    executor
+                        .execute_streaming(pooled.get_connection(), sql_str)
+                        .map(crate::engine::StreamState::InMemory)
+                }
+            }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
+            return 0;
+        };
+        restore_pooled_connection(&mut state, conn_id, target);
+
         match stream_state {
             Ok(stream_state) => {
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    return 0;
-                };
                 let stream_id = {
                     let mut id = 0u32;
                     for _ in 0..MAX_ID_ALLOC_ATTEMPTS {
@@ -4839,10 +4771,6 @@ pub extern "C" fn odbc_stream_start(
                 stream_id
             }
             Err(e) => {
-                drop(state);
-                let Some(mut state) = try_lock_global_state() else {
-                    return 0;
-                };
                 set_connection_error(
                     &mut state,
                     conn_id,
@@ -5976,46 +5904,51 @@ pub extern "C" fn odbc_bulk_insert_array(
         let Some(mut state) = try_lock_global_state() else {
             return -1;
         };
-        let conn = match state.connections.get(&conn_id) {
-            Some(c) => c,
-            None => {
-                set_connection_error(
-                    &mut state,
-                    conn_id,
-                    format!("Invalid connection ID: {}", conn_id),
-                );
-                return -1;
-            }
-        };
-
-        let handles = conn.get_handles();
-        let Ok(handles_guard) = handles.lock() else {
-            set_error(&mut state, "Failed to lock handles mutex".to_string());
-            return -1;
-        };
-        let conn_arc = match handles_guard.get_connection(conn_id) {
-            Ok(c) => c,
+        #[cfg(feature = "sqlserver-bcp")]
+        let conn_str_owned = state.connection_strings.get(&conn_id).cloned();
+        let mut target = match take_runnable_connection(&mut state, conn_id) {
+            Ok(target) => target,
             Err(e) => {
-                set_error(&mut state, format!("Failed to get connection: {}", e));
+                set_connection_structured_error(&mut state, conn_id, e.to_structured());
                 return -1;
             }
         };
-        drop(handles_guard);
-
-        let conn_guard = match conn_arc.lock() {
-            Ok(g) => g,
-            Err(_) => {
-                set_error(&mut state, "Failed to lock connection".to_string());
-                return -1;
-            }
-        };
+        drop(state);
 
         #[cfg(feature = "sqlserver-bcp")]
-        let conn_str = state.connection_strings.get(&conn_id).map(String::as_str);
+        let conn_str = conn_str_owned.as_deref();
         #[cfg(not(feature = "sqlserver-bcp"))]
         let conn_str: Option<&str> = None;
 
-        match bulk_insert_payload(conn_guard.connection(), &payload, conn_str) {
+        let result = match &mut target {
+            RunnableConnection::Regular(conn_arc) => {
+                let conn_guard = match conn_arc.lock() {
+                    Ok(g) => g,
+                    Err(_) => {
+                        let Some(mut state) = try_lock_global_state() else {
+                            return -1;
+                        };
+                        set_connection_error(
+                            &mut state,
+                            conn_id,
+                            "Failed to lock connection".to_string(),
+                        );
+                        return -1;
+                    }
+                };
+                bulk_insert_payload(conn_guard.connection(), &payload, conn_str)
+            }
+            RunnableConnection::Pooled { pooled, .. } => {
+                bulk_insert_payload(pooled.get_connection(), &payload, conn_str)
+            }
+        };
+
+        let Some(mut state) = try_lock_global_state() else {
+            return -1;
+        };
+        restore_pooled_connection(&mut state, conn_id, target);
+
+        match result {
             Ok(total) => {
                 unsafe {
                     *rows_inserted = total as c_uint;
@@ -6050,6 +5983,28 @@ fn bulk_insert_payload(
     }
 }
 
+fn bulk_insert_payload_range(
+    conn: &odbc_api::Connection<'static>,
+    payload: &BulkInsertPayload,
+    conn_str: Option<&str>,
+    start: usize,
+    end: usize,
+) -> Result<usize> {
+    #[cfg(feature = "sqlserver-bcp")]
+    {
+        // Native BCP currently consumes an owned BulkInsertPayload, so parallel
+        // BCP keeps the chunk materialization fallback. The default array
+        // binding path below uses the original payload by row range.
+        let chunk = slice_payload_rows(payload, start, end)?;
+        bulk_insert_payload(conn, &chunk, conn_str)
+    }
+    #[cfg(not(feature = "sqlserver-bcp"))]
+    {
+        let _ = conn_str;
+        ArrayBinding::default().bulk_insert_generic_range(conn, payload, start, end)
+    }
+}
+
 fn row_chunk_ranges(row_count: usize, parallelism: usize) -> Vec<(usize, usize)> {
     if row_count == 0 {
         return Vec::new();
@@ -6062,6 +6017,7 @@ fn row_chunk_ranges(row_count: usize, parallelism: usize) -> Vec<(usize, usize)>
         .collect()
 }
 
+#[cfg(feature = "sqlserver-bcp")]
 fn slice_null_bitmap(bitmap: &[u8], start: usize, len: usize) -> Vec<u8> {
     let mut out = vec![0u8; len.div_ceil(8)];
     for i in 0..len {
@@ -6072,6 +6028,7 @@ fn slice_null_bitmap(bitmap: &[u8], start: usize, len: usize) -> Vec<u8> {
     out
 }
 
+#[cfg(feature = "sqlserver-bcp")]
 fn slice_payload_rows(
     payload: &BulkInsertPayload,
     start: usize,
@@ -6166,8 +6123,7 @@ fn bulk_insert_parallel_with_pool(
         .map(|(start, end)| {
             let pooled = pool.get()?;
             let odbc_conn = pooled.get_connection();
-            let chunk = slice_payload_rows(payload, start, end)?;
-            bulk_insert_payload(odbc_conn, &chunk, Some(conn_str))
+            bulk_insert_payload_range(odbc_conn, payload, Some(conn_str), start, end)
         })
         .collect();
 
@@ -6278,8 +6234,8 @@ pub extern "C" fn odbc_bulk_insert_parallel(
 mod tests {
     use super::*;
     use crate::protocol::{
-        serialize_bulk_insert_payload, serialize_params, BulkColumnData, BulkColumnSpec,
-        BulkColumnType, BulkInsertPayload, ParamValue,
+        serialize_bulk_insert_payload, serialize_bulk_insert_payload_v2, serialize_params,
+        BulkColumnData, BulkColumnSpec, BulkColumnType, BulkInsertPayload, ParamValue,
     };
     use serde_json::Value;
     use serial_test::serial;
@@ -6317,6 +6273,108 @@ mod tests {
 
         let len = result as usize;
         String::from_utf8_lossy(&buffer[..len]).to_string()
+    }
+
+    #[test]
+    #[serial(ffi_last_error)]
+    fn test_pending_result_replay_removes_buffer_after_success() {
+        odbc_init();
+        let key = PendingResultKey::ExecQueryMulti {
+            conn_id: 77,
+            sql_hash: hash_bytes(b"SELECT 1"),
+        };
+        let mut out = [0u8; 8];
+        let mut written: c_uint = 0;
+
+        let Some(mut state) = try_lock_global_state() else {
+            panic!("Failed to lock global state");
+        };
+        stash_pending_result(&mut state, key.clone(), vec![1, 2, 3, 4]);
+        let code = try_write_pending_result(
+            &mut state,
+            &key,
+            out.as_mut_ptr(),
+            out.len() as c_uint,
+            &mut written,
+            Some(77),
+        );
+
+        assert_eq!(code, Some(0));
+        assert_eq!(written, 4);
+        assert_eq!(&out[..4], &[1, 2, 3, 4]);
+        assert!(!state.pending_result_buffers.contains_key(&key));
+    }
+
+    #[test]
+    #[serial(ffi_last_error)]
+    fn test_pending_result_replay_keeps_buffer_when_retry_too_small() {
+        odbc_init();
+        let key = PendingResultKey::Execute {
+            stmt_id: 11,
+            params_hash: hash_bytes(b"params"),
+            timeout_override_ms: 0,
+            fetch_size: 0,
+        };
+        let mut out = [0u8; 2];
+        let mut written: c_uint = 123;
+
+        let Some(mut state) = try_lock_global_state() else {
+            panic!("Failed to lock global state");
+        };
+        stash_pending_result(&mut state, key.clone(), vec![9, 8, 7, 6]);
+        let code = try_write_pending_result(
+            &mut state,
+            &key,
+            out.as_mut_ptr(),
+            out.len() as c_uint,
+            &mut written,
+            Some(11),
+        );
+
+        assert_eq!(code, Some(-2));
+        assert_eq!(written, 0);
+        assert!(state.pending_result_buffers.contains_key(&key));
+        assert!(
+            get_connection_error(&state, Some(11)).contains("Buffer too small"),
+            "per-connection pending error should be written"
+        );
+    }
+
+    #[test]
+    #[serial(ffi_last_error)]
+    fn test_connection_errors_are_isolated_by_connection_id() {
+        odbc_init();
+        let Some(mut state) = try_lock_global_state() else {
+            panic!("Failed to lock global state");
+        };
+
+        set_connection_error(&mut state, 101, "conn 101 failed".to_string());
+        set_connection_error(&mut state, 202, "conn 202 failed".to_string());
+
+        assert_eq!(get_connection_error(&state, Some(101)), "conn 101 failed");
+        assert_eq!(get_connection_error(&state, Some(202)), "conn 202 failed");
+    }
+
+    #[test]
+    fn test_simulated_long_call_can_reacquire_global_state_after_lookup() {
+        odbc_init();
+        {
+            let Some(_lookup_phase) = try_lock_global_state() else {
+                panic!("Failed to lock global state");
+            };
+        }
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let reacquired = try_lock_global_state().is_some();
+            tx.send(reacquired).expect("send lock result");
+        });
+
+        assert_eq!(
+            rx.recv_timeout(Duration::from_millis(250)),
+            Ok(true),
+            "simulated ODBC execution must not keep GLOBAL_STATE locked"
+        );
     }
 
     fn trigger_structured_cancel_unsupported_error() {
@@ -8717,6 +8775,84 @@ mod tests {
             "Error should mention invalid connection, payload, or buffer: {}",
             err
         );
+    }
+
+    #[test]
+    fn test_ffi_bulk_insert_array_accepts_v2_payload_before_connection_lookup() {
+        odbc_init();
+        let payload = BulkInsertPayload {
+            table: "t".to_string(),
+            columns: vec![BulkColumnSpec {
+                name: "blob".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: false,
+                max_len: 8,
+            }],
+            row_count: 1,
+            column_data: vec![BulkColumnData::Binary {
+                rows: vec![vec![1, 0, 2]],
+                max_len: 8,
+                null_bitmap: None,
+            }],
+        };
+        let enc = serialize_bulk_insert_payload_v2(&payload).unwrap();
+        let mut rows: c_uint = 0;
+        let r = odbc_bulk_insert_array(
+            TEST_INVALID_ID,
+            std::ptr::null(),
+            std::ptr::null(),
+            0,
+            enc.as_ptr(),
+            enc.len() as c_uint,
+            0,
+            &mut rows,
+        );
+
+        assert_eq!(r, -1, "Invalid conn_id should return -1 after v2 parse");
+        let err = get_last_error();
+        assert!(
+            err.contains("Invalid handle") || err.contains(&TEST_INVALID_ID.to_string()),
+            "v2 payload should parse before connection lookup, got: {}",
+            err
+        );
+    }
+
+    #[test]
+    fn test_bulk_parallel_row_chunk_ranges_cover_all_rows() {
+        assert_eq!(row_chunk_ranges(0, 4), Vec::<(usize, usize)>::new());
+        assert_eq!(row_chunk_ranges(5, 1), vec![(0, 5)]);
+        assert_eq!(row_chunk_ranges(5, 2), vec![(0, 3), (3, 5)]);
+        assert_eq!(
+            row_chunk_ranges(5, 8),
+            vec![(0, 1), (1, 2), (2, 3), (3, 4), (4, 5)]
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "sqlserver-bcp")]
+    fn test_bulk_parallel_bcp_chunk_fallback_preserves_binary_nul() {
+        let payload = BulkInsertPayload {
+            table: "t".to_string(),
+            columns: vec![BulkColumnSpec {
+                name: "blob".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: true,
+                max_len: 8,
+            }],
+            row_count: 3,
+            column_data: vec![BulkColumnData::Binary {
+                rows: vec![vec![1], vec![2, 0, 3], vec![4]],
+                max_len: 8,
+                null_bitmap: Some(vec![0]),
+            }],
+        };
+
+        let chunk = slice_payload_rows(&payload, 1, 2).unwrap();
+        assert_eq!(chunk.row_count, 1);
+        match &chunk.column_data[0] {
+            BulkColumnData::Binary { rows, .. } => assert_eq!(rows, &vec![vec![2, 0, 3]]),
+            other => panic!("unexpected chunk data: {other:?}"),
+        }
     }
 
     #[test]

--- a/native/odbc_engine/src/protocol/bulk_insert.rs
+++ b/native/odbc_engine/src/protocol/bulk_insert.rs
@@ -394,11 +394,7 @@ fn parse_column_data(
             let mut rows = Vec::with_capacity(row_count);
             for _ in 0..row_count {
                 let raw = read_bytes(data, &mut o, max_len)?;
-                let mut v = raw.to_vec();
-                if let Some(trimmed) = v.iter().position(|&b| b == 0) {
-                    v.truncate(trimmed);
-                }
-                rows.push(v);
+                rows.push(trim_legacy_nul_padded_cell(raw).to_vec());
             }
             Ok((
                 BulkColumnData::Text {
@@ -415,11 +411,7 @@ fn parse_column_data(
             let mut rows = Vec::with_capacity(row_count);
             for _ in 0..row_count {
                 let raw = read_bytes(data, &mut o, max_len)?;
-                let mut v = raw.to_vec();
-                if let Some(trimmed) = v.iter().position(|&b| b == 0) {
-                    v.truncate(trimmed);
-                }
-                rows.push(v);
+                rows.push(trim_legacy_nul_padded_cell(raw).to_vec());
             }
             Ok((
                 BulkColumnData::Binary {
@@ -467,6 +459,11 @@ fn parse_column_data(
             ))
         }
     }
+}
+
+fn trim_legacy_nul_padded_cell(raw: &[u8]) -> &[u8] {
+    let end = raw.iter().position(|&b| b == 0).unwrap_or(raw.len());
+    &raw[..end]
 }
 
 fn parse_column_data_v2(
@@ -565,7 +562,7 @@ fn serialize_bulk_insert_payload_with_wire(
             payload.row_count
         )));
     }
-    let mut out = Vec::new();
+    let mut out = Vec::with_capacity(estimate_serialized_payload_size(payload, wire)?);
     if wire == BulkPayloadWire::V2 {
         out.extend_from_slice(BULK_V2_MAGIC);
         out.extend_from_slice(&BULK_V2_VERSION.to_le_bytes());
@@ -605,6 +602,78 @@ fn serialize_bulk_insert_payload_with_wire(
     }
 
     Ok(out)
+}
+
+fn estimate_serialized_payload_size(
+    payload: &BulkInsertPayload,
+    wire: BulkPayloadWire,
+) -> Result<usize> {
+    let mut size = 0usize;
+    if wire == BulkPayloadWire::V2 {
+        size = checked_payload_size_add(size, BULK_V2_MAGIC.len())?;
+        size = checked_payload_size_add(size, 2)?; // version
+        size = checked_payload_size_add(size, 2)?; // flags
+    }
+
+    size = checked_payload_size_add(size, 4)?; // table length
+    size = checked_payload_size_add(size, payload.table.len())?;
+    size = checked_payload_size_add(size, 4)?; // column count
+
+    for spec in &payload.columns {
+        size = checked_payload_size_add(size, 4)?; // column name length
+        size = checked_payload_size_add(size, spec.name.len())?;
+        size = checked_payload_size_add(size, 1)?; // type tag
+        size = checked_payload_size_add(size, 1)?; // nullable
+        size = checked_payload_size_add(size, 4)?; // max_len
+    }
+
+    size = checked_payload_size_add(size, 4)?; // row count
+
+    let row_count = payload.row_count as usize;
+    for (spec, data) in payload.columns.iter().zip(payload.column_data.iter()) {
+        if spec.nullable {
+            size = checked_payload_size_add(size, null_bitmap_size(row_count))?;
+        }
+        size = checked_payload_size_add(
+            size,
+            match (wire, data, &spec.col_type) {
+                (_, BulkColumnData::I32 { values, .. }, BulkColumnType::I32) => {
+                    checked_payload_size_mul(values.len(), 4)?
+                }
+                (_, BulkColumnData::I64 { values, .. }, BulkColumnType::I64) => {
+                    checked_payload_size_mul(values.len(), 8)?
+                }
+                (_, BulkColumnData::Timestamp { values, .. }, BulkColumnType::Timestamp) => {
+                    checked_payload_size_mul(values.len(), 16)?
+                }
+                (BulkPayloadWire::Legacy, BulkColumnData::Text { rows, max_len, .. }, _)
+                | (BulkPayloadWire::Legacy, BulkColumnData::Binary { rows, max_len, .. }, _) => {
+                    checked_payload_size_mul(rows.len(), *max_len)?
+                }
+                (BulkPayloadWire::V2, BulkColumnData::Text { rows, .. }, _)
+                | (BulkPayloadWire::V2, BulkColumnData::Binary { rows, .. }, _) => {
+                    rows.iter().try_fold(0usize, |acc, row| {
+                        checked_payload_size_add(acc, 4)
+                            .and_then(|acc| checked_payload_size_add(acc, row.len()))
+                    })?
+                }
+                _ => 0,
+            },
+        )?;
+    }
+
+    Ok(size)
+}
+
+fn checked_payload_size_add(current: usize, added: usize) -> Result<usize> {
+    current
+        .checked_add(added)
+        .ok_or_else(|| OdbcError::ResourceLimitReached("bulk payload size overflow".to_string()))
+}
+
+fn checked_payload_size_mul(left: usize, right: usize) -> Result<usize> {
+    left.checked_mul(right)
+        .ok_or_else(|| OdbcError::ResourceLimitReached("bulk payload size overflow".to_string()))
 }
 
 fn serialize_column_data(
@@ -876,6 +945,38 @@ mod tests {
             }
             _ => panic!("expected Text"),
         }
+    }
+
+    #[test]
+    fn legacy_parse_trims_nul_padding_before_copying_cell() {
+        assert_eq!(trim_legacy_nul_padded_cell(b"abc\0\0"), b"abc");
+        assert_eq!(trim_legacy_nul_padded_cell(b"abc"), b"abc");
+        assert_eq!(trim_legacy_nul_padded_cell(b"\0abc"), b"");
+    }
+
+    #[test]
+    fn estimate_serialized_payload_size_matches_v2_length() {
+        let payload = BulkInsertPayload {
+            table: "files".to_string(),
+            columns: vec![BulkColumnSpec {
+                name: "payload".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: false,
+                max_len: 0,
+            }],
+            row_count: 2,
+            column_data: vec![BulkColumnData::Binary {
+                rows: vec![vec![1, 0, 2], vec![3, 4]],
+                max_len: 0,
+                null_bitmap: None,
+            }],
+        };
+
+        let estimated =
+            estimate_serialized_payload_size(&payload, BulkPayloadWire::V2).expect("estimate");
+        let encoded = serialize_bulk_insert_payload_v2(&payload).expect("serialize");
+
+        assert_eq!(estimated, encoded.len());
     }
 
     #[test]

--- a/native/odbc_engine/src/protocol/bulk_insert.rs
+++ b/native/odbc_engine/src/protocol/bulk_insert.rs
@@ -13,6 +13,10 @@ pub const MAX_BULK_ROWS: usize = 10_000_000;
 /// VARCHAR/VARBINARY widths.
 pub const MAX_BULK_CELL_LEN: usize = 16 * 1024 * 1024;
 
+const BULK_V2_MAGIC: &[u8; 4] = b"BLK2";
+const BULK_V2_VERSION: u16 = 2;
+const BULK_V2_FLAGS_NONE: u16 = 0;
+
 const TAG_I32: u8 = 0;
 const TAG_I64: u8 = 1;
 const TAG_TEXT: u8 = 2;
@@ -127,6 +131,17 @@ fn read_u32_le(data: &[u8], offset: &mut usize) -> Result<u32> {
     Ok(v)
 }
 
+fn read_u16_le(data: &[u8], offset: &mut usize) -> Result<u16> {
+    if data.len().saturating_sub(*offset) < 2 {
+        return Err(OdbcError::ValidationError(
+            "Bulk insert payload truncated (u16)".to_string(),
+        ));
+    }
+    let v = u16::from_le_bytes([data[*offset], data[*offset + 1]]);
+    *offset += 2;
+    Ok(v)
+}
+
 fn read_bytes<'a>(data: &'a [u8], offset: &mut usize, len: usize) -> Result<&'a [u8]> {
     if data.len().saturating_sub(*offset) < len {
         return Err(OdbcError::ValidationError(
@@ -175,16 +190,54 @@ pub fn is_null_strict(bitmap: &[u8], row: usize, row_count: usize) -> Result<boo
 }
 
 pub fn parse_bulk_insert_payload(data: &[u8]) -> Result<BulkInsertPayload> {
-    let mut o = 0usize;
+    if data.starts_with(BULK_V2_MAGIC) {
+        parse_bulk_insert_payload_v2(data)
+    } else {
+        parse_bulk_insert_payload_legacy(data)
+    }
+}
 
-    let table_len = read_u32_le(data, &mut o)? as usize;
-    let table_bytes = read_bytes(data, &mut o, table_len)?;
+fn parse_bulk_insert_payload_legacy(data: &[u8]) -> Result<BulkInsertPayload> {
+    let mut o = 0usize;
+    parse_bulk_insert_payload_body(data, &mut o, BulkPayloadWire::Legacy)
+}
+
+fn parse_bulk_insert_payload_v2(data: &[u8]) -> Result<BulkInsertPayload> {
+    let mut o = BULK_V2_MAGIC.len();
+    let version = read_u16_le(data, &mut o)?;
+    if version != BULK_V2_VERSION {
+        return Err(OdbcError::ValidationError(format!(
+            "Unsupported bulk insert payload version: {version}"
+        )));
+    }
+    let flags = read_u16_le(data, &mut o)?;
+    if flags != BULK_V2_FLAGS_NONE {
+        return Err(OdbcError::ValidationError(format!(
+            "Unsupported bulk insert payload flags: {flags}"
+        )));
+    }
+    parse_bulk_insert_payload_body(data, &mut o, BulkPayloadWire::V2)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BulkPayloadWire {
+    Legacy,
+    V2,
+}
+
+fn parse_bulk_insert_payload_body(
+    data: &[u8],
+    o: &mut usize,
+    wire: BulkPayloadWire,
+) -> Result<BulkInsertPayload> {
+    let table_len = read_u32_le(data, o)? as usize;
+    let table_bytes = read_bytes(data, o, table_len)?;
     let table = str::from_utf8(table_bytes).map_err(|_| {
         OdbcError::ValidationError("Bulk insert table name invalid UTF-8".to_string())
     })?;
     let table = table.to_string();
 
-    let col_count = read_u32_le(data, &mut o)? as usize;
+    let col_count = read_u32_le(data, o)? as usize;
     if col_count > MAX_BULK_COLUMNS {
         return Err(OdbcError::ResourceLimitReached(format!(
             "column count {col_count} exceeds MAX_BULK_COLUMNS={MAX_BULK_COLUMNS}"
@@ -192,28 +245,28 @@ pub fn parse_bulk_insert_payload(data: &[u8]) -> Result<BulkInsertPayload> {
     }
     let mut columns = Vec::with_capacity(col_count);
     for _ in 0..col_count {
-        let name_len = read_u32_le(data, &mut o)? as usize;
-        let name_bytes = read_bytes(data, &mut o, name_len)?;
+        let name_len = read_u32_le(data, o)? as usize;
+        let name_bytes = read_bytes(data, o, name_len)?;
         let name = str::from_utf8(name_bytes).map_err(|_| {
             OdbcError::ValidationError("Bulk insert column name invalid UTF-8".to_string())
         })?;
         let name = name.to_string();
-        if data.len() <= o {
+        if data.len() <= *o {
             return Err(OdbcError::ValidationError(
                 "Bulk insert payload truncated (column spec)".to_string(),
             ));
         }
-        let type_tag = data[o];
-        o += 1;
-        let nullable = if data.len() <= o {
+        let type_tag = data[*o];
+        *o += 1;
+        let nullable = if data.len() <= *o {
             return Err(OdbcError::ValidationError(
                 "Bulk insert payload truncated (nullable)".to_string(),
             ));
         } else {
-            data[o] != 0
+            data[*o] != 0
         };
-        o += 1;
-        let max_len = read_u32_le(data, &mut o)? as usize;
+        *o += 1;
+        let max_len = read_u32_le(data, o)? as usize;
         if max_len > MAX_BULK_CELL_LEN {
             return Err(OdbcError::ResourceLimitReached(format!(
                 "max_len {max_len} exceeds MAX_BULK_CELL_LEN={MAX_BULK_CELL_LEN}"
@@ -228,7 +281,7 @@ pub fn parse_bulk_insert_payload(data: &[u8]) -> Result<BulkInsertPayload> {
         });
     }
 
-    let row_count = read_u32_le(data, &mut o)? as usize;
+    let row_count = read_u32_le(data, o)? as usize;
     if row_count > MAX_BULK_ROWS {
         return Err(OdbcError::ResourceLimitReached(format!(
             "row count {row_count} exceeds MAX_BULK_ROWS={MAX_BULK_ROWS}"
@@ -237,12 +290,15 @@ pub fn parse_bulk_insert_payload(data: &[u8]) -> Result<BulkInsertPayload> {
 
     let mut column_data = Vec::with_capacity(columns.len());
     for spec in &columns {
-        let (data_col, consumed) = parse_column_data(data, o, spec, row_count)?;
+        let (data_col, consumed) = match wire {
+            BulkPayloadWire::Legacy => parse_column_data(data, *o, spec, row_count)?,
+            BulkPayloadWire::V2 => parse_column_data_v2(data, *o, spec, row_count)?,
+        };
         column_data.push(data_col);
-        o += consumed;
+        *o += consumed;
     }
 
-    if o != data.len() {
+    if *o != data.len() {
         return Err(OdbcError::ValidationError(
             "Bulk insert payload length mismatch".to_string(),
         ));
@@ -413,6 +469,67 @@ fn parse_column_data(
     }
 }
 
+fn parse_column_data_v2(
+    data: &[u8],
+    start: usize,
+    spec: &BulkColumnSpec,
+    row_count: usize,
+) -> Result<(BulkColumnData, usize)> {
+    let mut o = start;
+
+    match &spec.col_type {
+        BulkColumnType::Text | BulkColumnType::Decimal => {
+            let null_bitmap = read_null_bitmap(data, &mut o, spec.nullable, row_count)?;
+            let mut rows = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
+                let len = read_u32_le(data, &mut o)? as usize;
+                validate_variable_cell_len(len, spec.max_len)?;
+                rows.push(read_bytes(data, &mut o, len)?.to_vec());
+            }
+            Ok((
+                BulkColumnData::Text {
+                    rows,
+                    max_len: spec.max_len,
+                    null_bitmap,
+                },
+                o - start,
+            ))
+        }
+        BulkColumnType::Binary => {
+            let null_bitmap = read_null_bitmap(data, &mut o, spec.nullable, row_count)?;
+            let mut rows = Vec::with_capacity(row_count);
+            for _ in 0..row_count {
+                let len = read_u32_le(data, &mut o)? as usize;
+                validate_variable_cell_len(len, spec.max_len)?;
+                rows.push(read_bytes(data, &mut o, len)?.to_vec());
+            }
+            Ok((
+                BulkColumnData::Binary {
+                    rows,
+                    max_len: spec.max_len,
+                    null_bitmap,
+                },
+                o - start,
+            ))
+        }
+        _ => parse_column_data(data, start, spec, row_count),
+    }
+}
+
+fn validate_variable_cell_len(len: usize, max_len: usize) -> Result<()> {
+    if len > MAX_BULK_CELL_LEN {
+        return Err(OdbcError::ResourceLimitReached(format!(
+            "cell length {len} exceeds MAX_BULK_CELL_LEN={MAX_BULK_CELL_LEN}"
+        )));
+    }
+    if max_len > 0 && len > max_len {
+        return Err(OdbcError::MalformedPayload(format!(
+            "cell length {len} exceeds column max_len {max_len}"
+        )));
+    }
+    Ok(())
+}
+
 /// Convert `usize` to `u32` for wire-format length fields, returning a
 /// validation error instead of silently truncating.
 fn len_to_u32(n: usize, what: &str) -> Result<u32> {
@@ -425,6 +542,17 @@ fn len_to_u32(n: usize, what: &str) -> Result<u32> {
 }
 
 pub fn serialize_bulk_insert_payload(payload: &BulkInsertPayload) -> Result<Vec<u8>> {
+    serialize_bulk_insert_payload_with_wire(payload, BulkPayloadWire::Legacy)
+}
+
+pub fn serialize_bulk_insert_payload_v2(payload: &BulkInsertPayload) -> Result<Vec<u8>> {
+    serialize_bulk_insert_payload_with_wire(payload, BulkPayloadWire::V2)
+}
+
+fn serialize_bulk_insert_payload_with_wire(
+    payload: &BulkInsertPayload,
+    wire: BulkPayloadWire,
+) -> Result<Vec<u8>> {
     if payload.columns.len() > MAX_BULK_COLUMNS {
         return Err(OdbcError::ResourceLimitReached(format!(
             "column count {} exceeds MAX_BULK_COLUMNS={MAX_BULK_COLUMNS}",
@@ -438,6 +566,11 @@ pub fn serialize_bulk_insert_payload(payload: &BulkInsertPayload) -> Result<Vec<
         )));
     }
     let mut out = Vec::new();
+    if wire == BulkPayloadWire::V2 {
+        out.extend_from_slice(BULK_V2_MAGIC);
+        out.extend_from_slice(&BULK_V2_VERSION.to_le_bytes());
+        out.extend_from_slice(&BULK_V2_FLAGS_NONE.to_le_bytes());
+    }
     let table_b = payload.table.as_bytes();
     out.extend_from_slice(&len_to_u32(table_b.len(), "table name")?.to_le_bytes());
     out.extend_from_slice(table_b);
@@ -461,7 +594,14 @@ pub fn serialize_bulk_insert_payload(payload: &BulkInsertPayload) -> Result<Vec<
     out.extend_from_slice(&payload.row_count.to_le_bytes());
 
     for (spec, data) in payload.columns.iter().zip(payload.column_data.iter()) {
-        serialize_column_data(&mut out, spec, data, payload.row_count as usize)?;
+        match wire {
+            BulkPayloadWire::Legacy => {
+                serialize_column_data(&mut out, spec, data, payload.row_count as usize)?
+            }
+            BulkPayloadWire::V2 => {
+                serialize_column_data_v2(&mut out, spec, data, payload.row_count as usize)?
+            }
+        }
     }
 
     Ok(out)
@@ -577,6 +717,67 @@ fn serialize_column_data(
     Ok(())
 }
 
+fn serialize_column_data_v2(
+    out: &mut Vec<u8>,
+    spec: &BulkColumnSpec,
+    data: &BulkColumnData,
+    row_count: usize,
+) -> Result<()> {
+    match (data, &spec.col_type) {
+        (
+            BulkColumnData::Text {
+                rows, null_bitmap, ..
+            },
+            BulkColumnType::Text,
+        )
+        | (
+            BulkColumnData::Text {
+                rows, null_bitmap, ..
+            },
+            BulkColumnType::Decimal,
+        ) => {
+            write_null_bitmap(out, null_bitmap);
+            write_variable_rows_v2(out, rows, spec.max_len, row_count)
+        }
+        (
+            BulkColumnData::Binary {
+                rows, null_bitmap, ..
+            },
+            BulkColumnType::Binary,
+        ) => {
+            write_null_bitmap(out, null_bitmap);
+            write_variable_rows_v2(out, rows, spec.max_len, row_count)
+        }
+        _ => serialize_column_data(out, spec, data, row_count),
+    }
+}
+
+fn write_null_bitmap(out: &mut Vec<u8>, null_bitmap: &Option<Vec<u8>>) {
+    if let Some(bm) = null_bitmap {
+        out.extend_from_slice(bm);
+    }
+}
+
+fn write_variable_rows_v2(
+    out: &mut Vec<u8>,
+    rows: &[Vec<u8>],
+    max_len: usize,
+    row_count: usize,
+) -> Result<()> {
+    if rows.len() != row_count {
+        return Err(OdbcError::MalformedPayload(format!(
+            "row count mismatch: expected {row_count}, got {}",
+            rows.len()
+        )));
+    }
+    for row in rows {
+        validate_variable_cell_len(row.len(), max_len)?;
+        out.extend_from_slice(&len_to_u32(row.len(), "cell length")?.to_le_bytes());
+        out.extend_from_slice(row);
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -675,6 +876,111 @@ mod tests {
             }
             _ => panic!("expected Text"),
         }
+    }
+
+    #[test]
+    fn parse_v2_preserves_binary_nul_bytes() {
+        let payload = BulkInsertPayload {
+            table: "files".to_string(),
+            columns: vec![BulkColumnSpec {
+                name: "payload".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: false,
+                max_len: 8,
+            }],
+            row_count: 1,
+            column_data: vec![BulkColumnData::Binary {
+                rows: vec![vec![1, 0, 2, 0, 3]],
+                max_len: 8,
+                null_bitmap: None,
+            }],
+        };
+
+        let enc = serialize_bulk_insert_payload_v2(&payload).expect("serialize v2");
+        assert_eq!(&enc[..4], b"BLK2");
+        let dec = parse_bulk_insert_payload(&enc).expect("parse v2");
+
+        match &dec.column_data[0] {
+            BulkColumnData::Binary { rows, max_len, .. } => {
+                assert_eq!(*max_len, 8);
+                assert_eq!(rows[0], vec![1, 0, 2, 0, 3]);
+            }
+            _ => panic!("expected Binary"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_accepts_variable_binary_when_max_len_zero() {
+        let payload = BulkInsertPayload {
+            table: "files".to_string(),
+            columns: vec![BulkColumnSpec {
+                name: "payload".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: false,
+                max_len: 0,
+            }],
+            row_count: 1,
+            column_data: vec![BulkColumnData::Binary {
+                rows: vec![vec![9, 8, 0, 7, 6]],
+                max_len: 0,
+                null_bitmap: None,
+            }],
+        };
+
+        let enc = serialize_bulk_insert_payload_v2(&payload).expect("serialize v2");
+        let dec = parse_bulk_insert_payload(&enc).expect("parse v2");
+
+        match &dec.column_data[0] {
+            BulkColumnData::Binary { rows, max_len, .. } => {
+                assert_eq!(*max_len, 0);
+                assert_eq!(rows[0], vec![9, 8, 0, 7, 6]);
+            }
+            _ => panic!("expected Binary"),
+        }
+    }
+
+    #[test]
+    fn parse_v2_rejects_cell_over_column_max_len() {
+        let mut enc = Vec::new();
+        enc.extend_from_slice(b"BLK2");
+        enc.extend_from_slice(&2u16.to_le_bytes());
+        enc.extend_from_slice(&0u16.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(b"t");
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(b"b");
+        enc.push(TAG_BINARY);
+        enc.push(0);
+        enc.extend_from_slice(&2u32.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(&3u32.to_le_bytes());
+        enc.extend_from_slice(&[1, 2, 3]);
+
+        let e = parse_bulk_insert_payload(&enc).expect_err("max len");
+        assert!(e.to_string().contains("exceeds column max_len"));
+    }
+
+    #[test]
+    fn parse_v2_rejects_truncated_variable_cell() {
+        let mut enc = Vec::new();
+        enc.extend_from_slice(b"BLK2");
+        enc.extend_from_slice(&2u16.to_le_bytes());
+        enc.extend_from_slice(&0u16.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(b"t");
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(b"b");
+        enc.push(TAG_BINARY);
+        enc.push(0);
+        enc.extend_from_slice(&8u32.to_le_bytes());
+        enc.extend_from_slice(&1u32.to_le_bytes());
+        enc.extend_from_slice(&4u32.to_le_bytes());
+        enc.extend_from_slice(&[1, 2]);
+
+        let e = parse_bulk_insert_payload(&enc).expect_err("truncated");
+        assert!(e.to_string().contains("truncated"));
     }
 
     #[test]

--- a/native/odbc_engine/src/protocol/columnar_encoder.rs
+++ b/native/odbc_engine/src/protocol/columnar_encoder.rs
@@ -51,83 +51,89 @@ impl ColumnarEncoder {
         );
         output.extend_from_slice(col_name_bytes);
 
-        let mut raw_data = Vec::with_capacity(Self::estimate_column_payload_size(col_block)?);
+        let raw_payload_size = Self::estimate_column_payload_size(col_block)?;
+        if !use_compression || raw_payload_size <= 100 {
+            output.push(0);
+            output.extend_from_slice(
+                &checked_u32(raw_payload_size, "column payload length")?.to_le_bytes(),
+            );
+            Self::encode_column_payload(output, col_block)?;
+            return Ok(());
+        }
 
+        let mut raw_data = Vec::with_capacity(raw_payload_size);
+        Self::encode_column_payload(&mut raw_data, col_block)?;
+
+        match compression::compress(&raw_data, CompressionType::Zstd) {
+            Ok(compressed) if compressed.len() < raw_data.len() => {
+                output.push(1);
+                output.push(CompressionType::Zstd as u8);
+                output.extend_from_slice(
+                    &checked_u32(compressed.len(), "column payload length")?.to_le_bytes(),
+                );
+                output.extend_from_slice(&compressed);
+            }
+            _ => {
+                output.push(0);
+                output.extend_from_slice(
+                    &checked_u32(raw_data.len(), "column payload length")?.to_le_bytes(),
+                );
+                output.extend_from_slice(&raw_data);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn encode_column_payload(output: &mut Vec<u8>, col_block: &ColumnBlock) -> Result<()> {
         match &col_block.data {
             ColumnData::Varchar(data) => {
                 for cell in data {
                     if let Some(bytes) = cell {
-                        raw_data.push(0);
-                        raw_data.extend_from_slice(
+                        output.push(0);
+                        output.extend_from_slice(
                             &checked_u32(bytes.len(), "varchar cell length")?.to_le_bytes(),
                         );
-                        raw_data.extend_from_slice(bytes);
+                        output.extend_from_slice(bytes);
                     } else {
-                        raw_data.push(1);
+                        output.push(1);
                     }
                 }
             }
             ColumnData::Integer(data) => {
                 for cell in data {
                     if let Some(value) = cell {
-                        raw_data.push(0);
-                        raw_data.extend_from_slice(&value.to_le_bytes());
+                        output.push(0);
+                        output.extend_from_slice(&value.to_le_bytes());
                     } else {
-                        raw_data.push(1);
+                        output.push(1);
                     }
                 }
             }
             ColumnData::BigInt(data) => {
                 for cell in data {
                     if let Some(value) = cell {
-                        raw_data.push(0);
-                        raw_data.extend_from_slice(&value.to_le_bytes());
+                        output.push(0);
+                        output.extend_from_slice(&value.to_le_bytes());
                     } else {
-                        raw_data.push(1);
+                        output.push(1);
                     }
                 }
             }
             ColumnData::Binary(data) => {
                 for cell in data {
                     if let Some(bytes) = cell {
-                        raw_data.push(0);
-                        raw_data.extend_from_slice(
+                        output.push(0);
+                        output.extend_from_slice(
                             &checked_u32(bytes.len(), "binary cell length")?.to_le_bytes(),
                         );
-                        raw_data.extend_from_slice(bytes);
+                        output.extend_from_slice(bytes);
                     } else {
-                        raw_data.push(1);
+                        output.push(1);
                     }
                 }
             }
         }
-
-        let (compressed_data, compression_type) = if use_compression && raw_data.len() > 100 {
-            match compression::compress(&raw_data, CompressionType::Zstd) {
-                Ok(compressed) if compressed.len() < raw_data.len() => {
-                    (compressed, CompressionType::Zstd)
-                }
-                _ => (raw_data, CompressionType::None),
-            }
-        } else {
-            (raw_data, CompressionType::None)
-        };
-
-        output.push(if compression_type != CompressionType::None {
-            1
-        } else {
-            0
-        });
-
-        if compression_type != CompressionType::None {
-            output.push(compression_type as u8);
-        }
-
-        output.extend_from_slice(
-            &checked_u32(compressed_data.len(), "column payload length")?.to_le_bytes(),
-        );
-        output.extend_from_slice(&compressed_data);
-
         Ok(())
     }
 

--- a/native/odbc_engine/src/protocol/decoder.rs
+++ b/native/odbc_engine/src/protocol/decoder.rs
@@ -110,10 +110,11 @@ impl BinaryProtocolDecoder {
                     "Buffer too small for column name".to_string(),
                 ));
             }
-            let name =
-                String::from_utf8(buffer[offset..offset + name_len].to_vec()).map_err(|e| {
+            let name = std::str::from_utf8(&buffer[offset..offset + name_len])
+                .map_err(|e| {
                     OdbcError::ValidationError(format!("Invalid UTF-8 in column name: {}", e))
-                })?;
+                })?
+                .to_owned();
             offset += name_len;
 
             columns.push(ColumnInfo { name, odbc_type });

--- a/native/odbc_engine/src/protocol/encoder.rs
+++ b/native/odbc_engine/src/protocol/encoder.rs
@@ -6,6 +6,7 @@ use thiserror::Error;
 
 const MAGIC: u32 = 0x4F444243;
 const VERSION: u16 = 1;
+const HEADER_SIZE: usize = 16;
 
 /// Appended after the v1 row-major message when a query used `OUT` / `INOUT` parameters.
 pub const OUTPUT_FOOTER_MAGIC: [u8; 4] = *b"OUT1";
@@ -16,6 +17,14 @@ pub const OUTPUT_FOOTER_MAGIC: [u8; 4] = *b"OUT1";
 pub const REF_CURSOR_FOOTER_MAGIC: [u8; 4] = [b'R', b'C', b'1', 0];
 
 pub struct RowBufferEncoder;
+
+#[derive(Clone, Copy)]
+struct EncodedShape {
+    column_count: u16,
+    row_count: u32,
+    payload_size: u32,
+    total_len: usize,
+}
 
 #[derive(Debug, Error)]
 pub enum EncodeError {
@@ -39,41 +48,28 @@ impl RowBufferEncoder {
     }
 
     pub fn try_encode(buffer: &RowBuffer) -> Result<Vec<u8>, EncodeError> {
-        let mut output = Vec::new();
-        Self::encode_to_writer(buffer, &mut output)?;
+        let shape = measure_buffer(buffer)?;
+        let mut output = Vec::with_capacity(shape.total_len);
+        Self::encode_to_writer_with_shape(buffer, &mut output, shape)?;
         Ok(output)
     }
 
     /// Encode buffer to a writer. Used for spill-to-disk when result exceeds memory threshold.
     pub fn encode_to_writer<W: Write>(buffer: &RowBuffer, w: &mut W) -> Result<(), EncodeError> {
-        let column_count = checked_u16_len(buffer.column_count(), "column count")?;
-        let row_count = checked_u32_len(buffer.row_count(), "row count")?;
-        let mut metadata_size = 0usize;
-        for col in &buffer.columns {
-            checked_u16_len(col.name.len(), "column name length")?;
-            metadata_size = checked_payload_add(metadata_size, 2, "column type")?;
-            metadata_size = checked_payload_add(metadata_size, 2, "column name length")?;
-            metadata_size = checked_payload_add(metadata_size, col.name.len(), "column name")?;
-        }
+        let shape = measure_buffer(buffer)?;
+        Self::encode_to_writer_with_shape(buffer, w, shape)
+    }
 
-        let mut payload_size = metadata_size;
-        for row in &buffer.rows {
-            for cell in row {
-                payload_size = checked_payload_add(payload_size, 1, "cell null flag")?;
-                if let Some(data) = cell {
-                    checked_u32_len(data.len(), "cell data length")?;
-                    payload_size = checked_payload_add(payload_size, 4, "cell data length")?;
-                    payload_size = checked_payload_add(payload_size, data.len(), "cell data")?;
-                }
-            }
-        }
-        let payload_size = checked_u32_len(payload_size, "payload size")?;
-
+    fn encode_to_writer_with_shape<W: Write>(
+        buffer: &RowBuffer,
+        w: &mut W,
+        shape: EncodedShape,
+    ) -> Result<(), EncodeError> {
         w.write_all(&MAGIC.to_le_bytes())?;
         w.write_all(&VERSION.to_le_bytes())?;
-        w.write_all(&column_count.to_le_bytes())?;
-        w.write_all(&row_count.to_le_bytes())?;
-        w.write_all(&payload_size.to_le_bytes())?;
+        w.write_all(&shape.column_count.to_le_bytes())?;
+        w.write_all(&shape.row_count.to_le_bytes())?;
+        w.write_all(&shape.payload_size.to_le_bytes())?;
 
         for col in &buffer.columns {
             w.write_all(&(col.odbc_type as u16).to_le_bytes())?;
@@ -158,6 +154,44 @@ impl RowBufferEncoder {
             Err(_) => Self::try_encode(buffer)?,
         })
     }
+}
+
+fn measure_buffer(buffer: &RowBuffer) -> Result<EncodedShape, EncodeError> {
+    let column_count = checked_u16_len(buffer.column_count(), "column count")?;
+    let row_count = checked_u32_len(buffer.row_count(), "row count")?;
+    let mut metadata_size = 0usize;
+    for col in &buffer.columns {
+        checked_u16_len(col.name.len(), "column name length")?;
+        metadata_size = checked_payload_add(metadata_size, 2, "column type")?;
+        metadata_size = checked_payload_add(metadata_size, 2, "column name length")?;
+        metadata_size = checked_payload_add(metadata_size, col.name.len(), "column name")?;
+    }
+
+    let mut payload_size = metadata_size;
+    for row in &buffer.rows {
+        for cell in row {
+            payload_size = checked_payload_add(payload_size, 1, "cell null flag")?;
+            if let Some(data) = cell {
+                checked_u32_len(data.len(), "cell data length")?;
+                payload_size = checked_payload_add(payload_size, 4, "cell data length")?;
+                payload_size = checked_payload_add(payload_size, data.len(), "cell data")?;
+            }
+        }
+    }
+    let payload_size = checked_u32_len(payload_size, "payload size")?;
+    let total_len =
+        HEADER_SIZE
+            .checked_add(payload_size as usize)
+            .ok_or(EncodeError::PayloadSizeOverflow {
+                context: "encoded row buffer",
+            })?;
+
+    Ok(EncodedShape {
+        column_count,
+        row_count,
+        payload_size,
+        total_len,
+    })
 }
 
 fn checked_u16_len(value: usize, field: &'static str) -> Result<u16, EncodeError> {

--- a/native/odbc_engine/src/protocol/mod.rs
+++ b/native/odbc_engine/src/protocol/mod.rs
@@ -20,8 +20,8 @@ pub use bound_param::{
     deserialize_param_buffer, is_directed_param_buffer, BoundParam, ParamDirection, ParamList,
 };
 pub use bulk_insert::{
-    parse_bulk_insert_payload, serialize_bulk_insert_payload, BulkColumnData, BulkColumnSpec,
-    BulkColumnType, BulkInsertPayload, BulkTimestamp,
+    parse_bulk_insert_payload, serialize_bulk_insert_payload, serialize_bulk_insert_payload_v2,
+    BulkColumnData, BulkColumnSpec, BulkColumnType, BulkInsertPayload, BulkTimestamp,
 };
 pub use columnar::{ColumnBlock, ColumnData, ColumnMetadata, CompressionType, RowBufferV2};
 pub use columnar_encoder::ColumnarEncoder;

--- a/native/odbc_engine/src/protocol/mod.rs
+++ b/native/odbc_engine/src/protocol/mod.rs
@@ -30,7 +30,8 @@ pub use converter::row_buffer_to_columnar;
 pub use decoder::{BinaryProtocolDecoder, ColumnInfo, DecodedResult};
 pub use encoder::RowBufferEncoder;
 pub use multi_result::{
-    decode_multi, encode_multi, MultiResultItem, MULTI_RESULT_MAGIC, MULTI_RESULT_VERSION,
+    decode_multi, encode_multi, try_encode_multi, MultiResultItem, MULTI_RESULT_MAGIC,
+    MULTI_RESULT_VERSION,
 };
 pub use param_value::{
     deserialize_params, has_null_param, max_param_string_len, param_count_exceeds_limit,

--- a/native/odbc_engine/src/protocol/multi_result.rs
+++ b/native/odbc_engine/src/protocol/multi_result.rs
@@ -43,13 +43,21 @@ pub enum MultiResultItem {
 
 /// Encode a list of items using the v2 framing (magic + version + count).
 pub fn encode_multi(items: &[MultiResultItem]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(HEADER_V2_LEN + estimate_payload_size(items));
+    try_encode_multi(items).expect("multi-result payload exceeds wire limits")
+}
+
+/// Checked variant of [`encode_multi`] for callers that prefer an error over a
+/// panic when a result set exceeds the wire-format limits.
+pub fn try_encode_multi(items: &[MultiResultItem]) -> Result<Vec<u8>> {
+    let capacity = checked_add_len(HEADER_V2_LEN, estimate_payload_size(items)?)?;
+    let count = checked_u32_len(items.len(), "multi-result item count")?;
+    let mut out = Vec::with_capacity(capacity);
     out.extend_from_slice(&MULTI_RESULT_MAGIC.to_le_bytes());
     out.extend_from_slice(&MULTI_RESULT_VERSION.to_le_bytes());
     out.extend_from_slice(&0u16.to_le_bytes()); // reserved
-    out.extend_from_slice(&(items.len() as u32).to_le_bytes());
-    encode_items(items, &mut out);
-    out
+    out.extend_from_slice(&count.to_le_bytes());
+    encode_items(items, &mut out)?;
+    Ok(out)
 }
 
 /// Encode using the legacy v1 framing (no magic, no version). Kept around for
@@ -57,18 +65,26 @@ pub fn encode_multi(items: &[MultiResultItem]) -> Vec<u8> {
 /// [`encode_multi`].
 #[doc(hidden)]
 pub fn encode_multi_v1(items: &[MultiResultItem]) -> Vec<u8> {
-    let mut out = Vec::with_capacity(4 + estimate_payload_size(items));
-    out.extend_from_slice(&(items.len() as u32).to_le_bytes());
-    encode_items(items, &mut out);
-    out
+    try_encode_multi_v1(items).expect("multi-result v1 payload exceeds wire limits")
 }
 
-fn encode_items(items: &[MultiResultItem], out: &mut Vec<u8>) {
+#[doc(hidden)]
+pub fn try_encode_multi_v1(items: &[MultiResultItem]) -> Result<Vec<u8>> {
+    let capacity = checked_add_len(4, estimate_payload_size(items)?)?;
+    let count = checked_u32_len(items.len(), "multi-result item count")?;
+    let mut out = Vec::with_capacity(capacity);
+    out.extend_from_slice(&count.to_le_bytes());
+    encode_items(items, &mut out)?;
+    Ok(out)
+}
+
+fn encode_items(items: &[MultiResultItem], out: &mut Vec<u8>) -> Result<()> {
     for item in items {
         match item {
             MultiResultItem::ResultSet(buf) => {
                 out.push(TAG_RESULT_SET);
-                out.extend_from_slice(&(buf.len() as u32).to_le_bytes());
+                let len = checked_u32_len(buf.len(), "multi-result item payload")?;
+                out.extend_from_slice(&len.to_le_bytes());
                 out.extend_from_slice(buf);
             }
             MultiResultItem::RowCount(n) => {
@@ -78,16 +94,34 @@ fn encode_items(items: &[MultiResultItem], out: &mut Vec<u8>) {
             }
         }
     }
+    Ok(())
 }
 
-fn estimate_payload_size(items: &[MultiResultItem]) -> usize {
-    items
-        .iter()
-        .map(|i| match i {
-            MultiResultItem::ResultSet(b) => 1 + 4 + b.len(),
-            MultiResultItem::RowCount(_) => 1 + 4 + 8,
-        })
-        .sum()
+fn estimate_payload_size(items: &[MultiResultItem]) -> Result<usize> {
+    let mut size = 0usize;
+    for item in items {
+        size = checked_add_len(size, MIN_ITEM_LEN)?;
+        size = checked_add_len(
+            size,
+            match item {
+                MultiResultItem::ResultSet(b) => b.len(),
+                MultiResultItem::RowCount(_) => 8,
+            },
+        )?;
+    }
+    Ok(size)
+}
+
+fn checked_u32_len(value: usize, field: &'static str) -> Result<u32> {
+    value.try_into().map_err(|_| {
+        OdbcError::ResourceLimitReached(format!("{field} length/count {value} does not fit in u32"))
+    })
+}
+
+fn checked_add_len(left: usize, right: usize) -> Result<usize> {
+    left.checked_add(right).ok_or_else(|| {
+        OdbcError::ResourceLimitReached("multi-result payload size overflow".to_string())
+    })
 }
 
 /// Decode a multi-result buffer. Accepts both the v2 framing (magic +
@@ -265,6 +299,23 @@ mod tests {
         let enc = encode_multi(&items);
         let dec = decode_multi(&enc).unwrap();
         assert_eq!(dec, items);
+    }
+
+    #[test]
+    fn try_encode_multi_matches_public_encoder() {
+        let items = vec![
+            MultiResultItem::ResultSet(vec![1, 2, 3]),
+            MultiResultItem::RowCount(-5),
+        ];
+
+        assert_eq!(try_encode_multi(&items).unwrap(), encode_multi(&items));
+    }
+
+    #[test]
+    fn checked_add_len_rejects_overflow() {
+        let err = checked_add_len(usize::MAX, 1).unwrap_err();
+
+        assert!(matches!(err, OdbcError::ResourceLimitReached(_)));
     }
 
     #[test]

--- a/native/odbc_engine/src/protocol/param_value.rs
+++ b/native/odbc_engine/src/protocol/param_value.rs
@@ -41,7 +41,24 @@ impl ParamValue {
     }
 
     pub fn try_serialize(&self) -> Result<Vec<u8>> {
-        let mut out = Vec::new();
+        let mut out = Vec::with_capacity(self.serialized_len()?);
+        self.write_to_vec(&mut out)?;
+        Ok(out)
+    }
+
+    fn serialized_len(&self) -> Result<usize> {
+        let payload_len = match self {
+            ParamValue::String(s) => checked_payload_len(s.len(), "ParamValue::String")? as usize,
+            ParamValue::Decimal(s) => checked_payload_len(s.len(), "ParamValue::Decimal")? as usize,
+            ParamValue::Binary(b) => checked_payload_len(b.len(), "ParamValue::Binary")? as usize,
+            ParamValue::Integer(_) => 4,
+            ParamValue::BigInt(_) => 8,
+            ParamValue::Null | ParamValue::RefCursorOut => 0,
+        };
+        Ok(5 + payload_len)
+    }
+
+    fn write_to_vec(&self, out: &mut Vec<u8>) -> Result<()> {
         match self {
             ParamValue::Null => {
                 out.push(TAG_NULL);
@@ -82,7 +99,7 @@ impl ParamValue {
                 out.extend_from_slice(&0u32.to_le_bytes());
             }
         }
-        Ok(out)
+        Ok(())
     }
 
     pub fn deserialize(data: &[u8]) -> Result<(Self, usize)> {
@@ -196,9 +213,15 @@ pub fn try_serialize_params(params: &[ParamValue]) -> Result<Vec<u8>> {
             MAX_PARAM_COUNT
         )));
     }
-    let mut out = Vec::new();
+    let capacity = params.iter().try_fold(0usize, |acc, param| {
+        let len = param.serialized_len()?;
+        acc.checked_add(len).ok_or_else(|| {
+            OdbcError::ResourceLimitReached("parameter buffer size overflow".to_string())
+        })
+    })?;
+    let mut out = Vec::with_capacity(capacity);
     for p in params {
-        out.extend(p.try_serialize()?);
+        p.write_to_vec(&mut out)?;
     }
     Ok(out)
 }
@@ -213,9 +236,7 @@ pub fn param_values_to_strings(params: &[ParamValue]) -> Result<Vec<Option<Strin
             ParamValue::BigInt(n) => out.push(Some(n.to_string())),
             ParamValue::Decimal(s) => out.push(Some(s.clone())),
             ParamValue::Binary(b) => {
-                out.push(Some(
-                    b.iter().map(|x| format!("{:02x}", x)).collect::<String>(),
-                ));
+                out.push(Some(bytes_to_lower_hex(b)));
             }
             ParamValue::RefCursorOut => {
                 return Err(OdbcError::ValidationError(
@@ -225,6 +246,16 @@ pub fn param_values_to_strings(params: &[ParamValue]) -> Result<Vec<Option<Strin
         }
     }
     Ok(out)
+}
+
+fn bytes_to_lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for &byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
 }
 
 pub fn param_value_to_input_parameter(param: &ParamValue) -> Result<Box<dyn InputParameter>> {

--- a/native/odbc_engine/tests/e2e_ffi_refactor_regression_test.rs
+++ b/native/odbc_engine/tests/e2e_ffi_refactor_regression_test.rs
@@ -1,0 +1,342 @@
+//! E2E coverage for FFI paths changed by the Rust/FFI refactor.
+//!
+//! These tests are opt-in through the normal E2E gate. They focus on behavior
+//! that unit tests cannot prove against a live driver: long calls must not hold
+//! `GLOBAL_STATE`, pool close/resize must respect in-flight pooled calls, bulk
+//! v2 binary cells must survive an actual insert/readback, and spill-backed
+//! streaming must fetch a real large result.
+
+use odbc_engine::ffi::{
+    odbc_bulk_insert_array, odbc_connect, odbc_disconnect, odbc_exec_query, odbc_get_error,
+    odbc_get_metrics, odbc_init, odbc_pool_close, odbc_pool_create, odbc_pool_get_connection,
+    odbc_pool_release_connection, odbc_pool_set_size, odbc_stream_close, odbc_stream_fetch,
+    odbc_stream_start,
+};
+use odbc_engine::protocol::{
+    serialize_bulk_insert_payload_v2, BulkColumnData, BulkColumnSpec, BulkColumnType,
+    BulkInsertPayload,
+};
+use odbc_engine::BinaryProtocolDecoder;
+use serial_test::serial;
+use std::ffi::CString;
+use std::os::raw::{c_char, c_uint};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+mod helpers;
+use helpers::e2e::{
+    get_connection_and_db_type, should_run_e2e_tests, sql_drop_table_if_exists, DatabaseType,
+};
+
+fn sql_server_dsn() -> Option<String> {
+    if !should_run_e2e_tests() {
+        eprintln!("Skipping FFI refactor E2E: ENABLE_E2E_TESTS + DSN not configured");
+        return None;
+    }
+
+    let (dsn, db_type) = get_connection_and_db_type()?;
+    if db_type != DatabaseType::SqlServer {
+        eprintln!("Skipping FFI refactor E2E: requires SQL Server, got {db_type:?}");
+        return None;
+    }
+
+    Some(dsn)
+}
+
+fn unique_table(prefix: &str) -> String {
+    static NEXT: AtomicUsize = AtomicUsize::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!(
+        "{}_{}_{}_{}",
+        prefix,
+        std::process::id(),
+        nanos,
+        NEXT.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+fn connect(dsn: &str) -> u32 {
+    odbc_init();
+    let conn = CString::new(dsn).expect("dsn must not contain NUL");
+    let conn_id = odbc_connect(conn.as_ptr());
+    assert!(conn_id > 0, "connect failed: {}", last_error());
+    conn_id
+}
+
+fn disconnect(conn_id: u32) {
+    assert_eq!(odbc_disconnect(conn_id), 0, "disconnect failed");
+}
+
+fn exec(conn_id: u32, sql: &str) -> Vec<u8> {
+    let sql = CString::new(sql).expect("sql must not contain NUL");
+    let mut buffer = vec![0u8; 4 * 1024 * 1024];
+    let mut written: c_uint = 0;
+    let code = odbc_exec_query(
+        conn_id,
+        sql.as_ptr(),
+        buffer.as_mut_ptr(),
+        buffer.len() as c_uint,
+        &mut written,
+    );
+    assert_eq!(code, 0, "exec failed: {}", last_error());
+    buffer.truncate(written as usize);
+    buffer
+}
+
+fn last_error() -> String {
+    let mut buffer = vec![0u8; 4096];
+    let len = odbc_get_error(buffer.as_mut_ptr() as *mut c_char, buffer.len() as c_uint);
+    if len <= 0 {
+        return String::new();
+    }
+    String::from_utf8_lossy(&buffer[..len as usize]).to_string()
+}
+
+fn decode_i64_cell(bytes: &[u8]) -> i64 {
+    match bytes.len() {
+        0..=3 => String::from_utf8_lossy(bytes).trim().parse().unwrap(),
+        4..=7 => i32::from_le_bytes(bytes[..4].try_into().unwrap()) as i64,
+        _ => i64::from_le_bytes(bytes[..8].try_into().unwrap()),
+    }
+}
+
+struct EnvGuard {
+    key: &'static str,
+    previous: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let previous = std::env::var_os(key);
+        std::env::set_var(key, value);
+        Self { key, previous }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(self.key, value),
+            None => std::env::remove_var(self.key),
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn bulk_v2_binary_nul_round_trips_through_ffi() {
+    let Some(dsn) = sql_server_dsn() else {
+        return;
+    };
+
+    let table = unique_table("odbc_bulk_v2_e2e");
+    let conn_id = connect(&dsn);
+    let drop_sql = sql_drop_table_if_exists(&table, DatabaseType::SqlServer);
+
+    exec(conn_id, &drop_sql);
+    exec(
+        conn_id,
+        &format!(
+            "CREATE TABLE {table} (id INT NOT NULL PRIMARY KEY, payload VARBINARY(8) NOT NULL)"
+        ),
+    );
+
+    let payload = BulkInsertPayload {
+        table: table.clone(),
+        columns: vec![
+            BulkColumnSpec {
+                name: "id".to_string(),
+                col_type: BulkColumnType::I32,
+                nullable: false,
+                max_len: 0,
+            },
+            BulkColumnSpec {
+                name: "payload".to_string(),
+                col_type: BulkColumnType::Binary,
+                nullable: false,
+                max_len: 8,
+            },
+        ],
+        row_count: 2,
+        column_data: vec![
+            BulkColumnData::I32 {
+                values: vec![1, 2],
+                null_bitmap: None,
+            },
+            BulkColumnData::Binary {
+                rows: vec![vec![1, 0, 2], vec![3, 4]],
+                null_bitmap: None,
+                max_len: 8,
+            },
+        ],
+    };
+    let encoded = serialize_bulk_insert_payload_v2(&payload).expect("encode bulk v2");
+    let table_c = CString::new(table.as_str()).unwrap();
+    let column_names = [
+        CString::new("id").unwrap(),
+        CString::new("payload").unwrap(),
+    ];
+    let column_ptrs = column_names.iter().map(|c| c.as_ptr()).collect::<Vec<_>>();
+    let mut rows_inserted: c_uint = 0;
+    let code = odbc_bulk_insert_array(
+        conn_id,
+        table_c.as_ptr(),
+        column_ptrs.as_ptr(),
+        column_ptrs.len() as c_uint,
+        encoded.as_ptr(),
+        encoded.len() as c_uint,
+        payload.row_count,
+        &mut rows_inserted,
+    );
+    assert_eq!(code, 0, "bulk insert failed: {}", last_error());
+    assert_eq!(rows_inserted, 2);
+
+    let result = exec(
+        conn_id,
+        &format!("SELECT id, payload, DATALENGTH(payload) AS payload_len FROM {table} ORDER BY id"),
+    );
+    let decoded = BinaryProtocolDecoder::parse(&result).expect("decode select");
+    assert_eq!(decoded.row_count, 2);
+    assert_eq!(decoded.rows[0][1].as_deref(), Some(&[1, 0, 2][..]));
+    assert_eq!(decode_i64_cell(decoded.rows[0][2].as_ref().unwrap()), 3);
+    assert_eq!(decoded.rows[1][1].as_deref(), Some(&[3, 4][..]));
+    assert_eq!(decode_i64_cell(decoded.rows[1][2].as_ref().unwrap()), 2);
+
+    exec(conn_id, &drop_sql);
+    disconnect(conn_id);
+}
+
+#[test]
+#[serial]
+fn long_ffi_query_does_not_block_global_metrics_lookup() {
+    let Some(dsn) = sql_server_dsn() else {
+        return;
+    };
+
+    let conn_id = connect(&dsn);
+    let long_query = CString::new("WAITFOR DELAY '00:00:02'; SELECT 1 AS n").unwrap();
+
+    let handle = std::thread::spawn(move || {
+        let mut buffer = vec![0u8; 8192];
+        let mut written: c_uint = 0;
+        odbc_exec_query(
+            conn_id,
+            long_query.as_ptr(),
+            buffer.as_mut_ptr(),
+            buffer.len() as c_uint,
+            &mut written,
+        )
+    });
+
+    std::thread::sleep(Duration::from_millis(250));
+    let start = Instant::now();
+    let mut metrics = [0u8; 40];
+    let mut written: c_uint = 0;
+    let metrics_code =
+        odbc_get_metrics(metrics.as_mut_ptr(), metrics.len() as c_uint, &mut written);
+    let elapsed = start.elapsed();
+
+    assert_eq!(metrics_code, 0, "metrics lookup failed: {}", last_error());
+    assert_eq!(written, 40);
+    assert!(
+        elapsed < Duration::from_millis(750),
+        "metrics lookup was blocked by long ODBC call for {elapsed:?}"
+    );
+
+    assert_eq!(handle.join().expect("long query thread panicked"), 0);
+    disconnect(conn_id);
+}
+
+#[test]
+#[serial]
+fn pool_resize_and_close_fail_while_pooled_query_is_in_flight() {
+    let Some(dsn) = sql_server_dsn() else {
+        return;
+    };
+
+    odbc_init();
+    let conn = CString::new(dsn).unwrap();
+    let pool_id = odbc_pool_create(conn.as_ptr(), 2);
+    assert!(pool_id > 0, "pool create failed: {}", last_error());
+
+    let pooled_id = odbc_pool_get_connection(pool_id);
+    assert!(pooled_id > 0, "pool checkout failed: {}", last_error());
+
+    let long_query = CString::new("WAITFOR DELAY '00:00:02'; SELECT 1 AS n").unwrap();
+    let handle = std::thread::spawn(move || {
+        let mut buffer = vec![0u8; 8192];
+        let mut written: c_uint = 0;
+        odbc_exec_query(
+            pooled_id,
+            long_query.as_ptr(),
+            buffer.as_mut_ptr(),
+            buffer.len() as c_uint,
+            &mut written,
+        )
+    });
+
+    std::thread::sleep(Duration::from_millis(250));
+    assert_eq!(
+        odbc_pool_set_size(pool_id, 3),
+        -1,
+        "resize must fail while a pooled connection is busy"
+    );
+    assert_ne!(
+        odbc_pool_close(pool_id),
+        0,
+        "close must fail while a pooled connection is busy"
+    );
+
+    assert_eq!(handle.join().expect("pooled query thread panicked"), 0);
+    assert_eq!(odbc_pool_release_connection(pooled_id), 0);
+    assert_eq!(odbc_pool_set_size(pool_id, 3), 0);
+    assert_eq!(odbc_pool_close(pool_id), 0);
+}
+
+#[test]
+#[serial]
+fn stream_start_spill_path_fetches_large_result() {
+    let Some(dsn) = sql_server_dsn() else {
+        return;
+    };
+
+    let _guard = EnvGuard::set("ODBC_STREAM_SPILL_THRESHOLD_MB", "1");
+    let conn_id = connect(&dsn);
+    let sql =
+        CString::new("SELECT REPLICATE(CAST('x' AS VARCHAR(MAX)), 1100000) AS large_text").unwrap();
+    let stream_id = odbc_stream_start(conn_id, sql.as_ptr(), 64 * 1024);
+    assert!(stream_id > 0, "stream start failed: {}", last_error());
+
+    let mut full = Vec::new();
+    let mut buffer = vec![0u8; 128 * 1024];
+    let mut written: c_uint = 0;
+    let mut has_more: u8 = 1;
+    while has_more != 0 {
+        let code = odbc_stream_fetch(
+            stream_id,
+            buffer.as_mut_ptr(),
+            buffer.len() as c_uint,
+            &mut written,
+            &mut has_more,
+        );
+        assert_eq!(code, 0, "stream fetch failed: {}", last_error());
+        full.extend_from_slice(&buffer[..written as usize]);
+    }
+
+    assert_eq!(odbc_stream_close(stream_id), 0);
+    disconnect(conn_id);
+
+    let decoded = BinaryProtocolDecoder::parse(&full).expect("decode streamed payload");
+    assert_eq!(decoded.row_count, 1);
+    let cell = decoded.rows[0][0]
+        .as_ref()
+        .expect("large_text should not be null");
+    assert!(
+        cell.len() >= 1_100_000,
+        "expected large streamed cell, got {} bytes",
+        cell.len()
+    );
+}

--- a/test/infrastructure/native/protocol/bulk_insert_builder_test.dart
+++ b/test/infrastructure/native/protocol/bulk_insert_builder_test.dart
@@ -119,7 +119,7 @@ void main() {
             .table('t')
             .addColumn('a', BulkColumnType.i32, nullable: true)
             .addRow([null]).addRow([1]);
-        final enc = b.build();
+        final enc = b.build(version: BulkPayloadVersion.legacy);
 
         // For nullable columns, there should be a null bitmap
         // Offset calculation: table(5) + col(15) + rowCount(4) = 24
@@ -286,6 +286,24 @@ void main() {
       );
     });
 
+    test('binary column rejects value longer than maxLen in addRow', () {
+      expect(
+        () => BulkInsertBuilder()
+            .table('t')
+            .addColumn('a', BulkColumnType.binary, maxLen: 2)
+            .addRow([
+          Uint8List.fromList([1, 2, 3]),
+        ]),
+        throwsA(
+          isA<ArgumentError>().having(
+            (e) => e.message,
+            'message',
+            contains('exceeds max length 2'),
+          ),
+        ),
+      );
+    });
+
     test('timestamp column rejects invalid value type in addRow', () {
       expect(
         () => BulkInsertBuilder()
@@ -330,7 +348,7 @@ void main() {
       // Ownership contract: mutating source list after addRow affects output.
       row[0] = 7;
 
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
 
       var o = 0;
@@ -371,7 +389,7 @@ void main() {
       expect(b.columnNames, equals(['a']));
       expect(b.rowCount, equals(2));
 
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
 
       var o = 0;
@@ -404,7 +422,7 @@ void main() {
           .table('t')
           .addColumn('a', BulkColumnType.i32, nullable: true)
           .addRow([1]).addRow([null]).addRow([3]);
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
 
       var o = 0;
@@ -430,7 +448,7 @@ void main() {
           .table('t')
           .addColumn('x', BulkColumnType.text, maxLen: 10)
           .addRow(['hi']).addRow(['world']);
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
 
       var o = 0;
@@ -470,13 +488,63 @@ void main() {
       expect(b.rowCount, 1);
     });
 
+    test('default build emits v2 BLK2 payload with per-cell binary length', () {
+      final b = BulkInsertBuilder()
+          .table('t')
+          .addColumn('p', BulkColumnType.binary, maxLen: 4)
+          .addRow([
+        Uint8List.fromList([1, 0, 2]),
+      ]);
+
+      final enc = b.build();
+      final view = ByteData.sublistView(enc);
+
+      expect(enc.sublist(0, 4), equals([0x42, 0x4C, 0x4B, 0x32]));
+      expect(view.getUint16(4, Endian.little), equals(2));
+      expect(view.getUint16(6, Endian.little), equals(0));
+
+      var o = 8;
+      o += 4 + 1; // table
+      o += 4; // column count
+      o += 4 + 1 + 1 + 1 + 4; // column metadata
+      o += 4; // row count
+      expect(view.getUint32(o, Endian.little), equals(3));
+      o += 4;
+      expect(enc.sublist(o, o + 3), equals([1, 0, 2]));
+    });
+
+    test('legacy build keeps fixed-width binary payload', () {
+      final b = BulkInsertBuilder()
+          .table('t')
+          .addColumn('p', BulkColumnType.binary, maxLen: 4)
+          .addRow([
+        Uint8List.fromList([1, 0, 2]),
+      ]);
+
+      final enc = b.build(version: BulkPayloadVersion.legacy);
+      var o = 0;
+      o += 4 + 1; // table
+      o += 4; // column count
+      o += 4 + 1 + 1 + 1 + 4; // column metadata
+      o += 4; // row count
+      expect(enc.sublist(o, o + 4), equals([1, 0, 2, 0]));
+    });
+
     test('serializes nullable variable-width and timestamp nulls', () {
       final b = BulkInsertBuilder()
           .table('events')
-          .addColumn('amount', BulkColumnType.decimal,
-              nullable: true, maxLen: 8,)
-          .addColumn('payload', BulkColumnType.binary,
-              nullable: true, maxLen: 4,)
+          .addColumn(
+            'amount',
+            BulkColumnType.decimal,
+            nullable: true,
+            maxLen: 8,
+          )
+          .addColumn(
+            'payload',
+            BulkColumnType.binary,
+            nullable: true,
+            maxLen: 4,
+          )
           .addColumn('created_at', BulkColumnType.timestamp, nullable: true)
           .addRow([null, null, null]);
 
@@ -553,7 +621,9 @@ void main() {
       final b = BulkInsertBuilder()
           .table('t')
           .addColumn('p', BulkColumnType.binary, maxLen: 4)
-          .addRow([Uint8List.fromList([7, 8])]);
+          .addRow([
+        Uint8List.fromList([7, 8]),
+      ]);
       expect(b.build(), isNotEmpty);
     });
 
@@ -564,7 +634,7 @@ void main() {
           .addColumn('a', BulkColumnType.i32)
           .addRow(row);
       row[0] = '42';
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
       var o = 0;
       o += 4 + 1;
@@ -575,13 +645,13 @@ void main() {
     });
 
     test('timestamp column uses zero sentinel when row mutated to string', () {
-      final row = <dynamic>[DateTime.utc(2020, 1, 1)];
+      final row = <dynamic>[DateTime.utc(2020)];
       final b = BulkInsertBuilder()
           .table('t')
           .addColumn('a', BulkColumnType.timestamp)
           .addRow(row);
       row[0] = 'unexpected';
-      final enc = b.build();
+      final enc = b.build(version: BulkPayloadVersion.legacy);
       final view = ByteData.sublistView(enc);
       var o = 0;
       o += 4 + 1;


### PR DESCRIPTION
## Summary
- add BulkInsert v2 wire payload support with Dart default emission and Rust v1/v2 autodetection
- avoid holding GLOBAL_STATE during long FFI ODBC query, execute, stream, and bulk operations
- improve parallel bulk chunking with ArrayBinding range execution, plus documented BCP fallback
- update changelog, FFI/data path/performance docs, and regression coverage

## Validation
- cargo fmt
- dart format lib\\infrastructure\\native\\protocol\\bulk_insert_builder.dart test\\infrastructure\\native\\protocol\\bulk_insert_builder_test.dart
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --lib --all-features
- cargo bench --no-run --all-features
- dart test test\\infrastructure\\native\\protocol\\bulk_insert_builder_test.dart
- dart analyze